### PR TITLE
feat: Add js page analysis MCP tool and CLI command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ MCP Agent  → MCP Server → Backends (Built-in Proxy or Burp MCP, OAST, Crawle
 - `sectool/service/mcp_jwt.go` - JWT decode tool handler
 - `sectool/service/mcp_diff.go` - Diff tool handler (structured flow comparison)
 - `sectool/service/mcp_reflection.go` - Reflection tool handler (parameter reflection detection)
+- `sectool/service/mcp_jsanalyze.go` - JS analyze tool handler (extract API surface from JS/HTML responses)
+- `sectool/service/js/` - JS bundle parser and extractors (tdewolff/parse/v2/js)
 - `sectool/service/mcp_notes.go` - Notes tool handlers (save, list) and flow listing attachment
 - `sectool/service/mcp_respond.go` - Proxy responder tool handlers (respond_add, respond_delete, respond_list); native backend only
 - `sectool/service/flags.go` - MCP server flag parsing (`--port`, `--workflow`, `--config`, `--notes`)
@@ -127,6 +129,8 @@ MCP Agent  → MCP Server → Backends (Built-in Proxy or Burp MCP, OAST, Crawle
 - `sectool/diff/diff.go` - Diff command implementation (CLI formatting and display)
 - `sectool/reflected/flags.go` - Reflected subcommand parsing
 - `sectool/reflected/reflected.go` - Reflected command implementation
+- `sectool/js/flags.go` - JS analyze subcommand parsing
+- `sectool/js/js.go` - JS analyze command implementation
 
 ### Shared CLI Utilities
 
@@ -229,6 +233,7 @@ Bundles at `./sectool-requests/<flow_id>/`: `request.http` (headers + body place
 - `jwt_decode` - decode and inspect JWT tokens
 - `diff_flow` - compare two captured flows with structured, content-type-aware diffing
 - `find_reflected` - detect request parameter values reflected in the response
+- `js_analyze` - extract API surface from a JavaScript or HTML flow (endpoints, routes, sockets, URL literals, external scripts)
 - `notes_save` - create, update, or delete notes/findings linked to flows (requires `--notes`)
 - `notes_list` - list saved notes with filters (requires `--notes`)
 
@@ -246,6 +251,7 @@ CLI requires a running MCP server. Maps to MCP tools via `sectool <module> <sub>
 - `jwt`: decode JWT tokens
 - `diff`: `<flow_a> <flow_b> --scope <scope>`
 - `reflected`: `<flow_id>`
+- `js`: `<flow_id>`
 - `version`
 
 ## Development Guidelines
@@ -279,6 +285,7 @@ Reach for stdlib `slices`/`maps`/`strings` and `github.com/go-analyze/bulk` befo
 - **Slice → map set**: `bulk.SliceToSet(s)` (returns `map[T]struct{}`). Membership tests use the comma-ok form: `if _, ok := set[k]; ok`.
 - **Map → slice of keys / values**: `bulk.MapKeysSlice(m)` and `bulk.MapValuesSlice(m)`. Don't write `for k := range m { keys = append(keys, k) }`.
 - **Membership check on a slice**: `slices.Contains(s, x)` for comparable element types, `slices.ContainsFunc(s, predicate)` for everything else.
+- **Sort a slice with a custom comparator**: `slices.SortFunc(s, cmp)` / `slices.SortStableFunc(s, cmp)`. Use instead of `sort.Slice` / `sort.SliceStable`.
 
 ### Testing
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	github.com/tdewolff/parse/v2 v2.8.12
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	golang.org/x/net v0.55.0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tdewolff/parse/v2 v2.8.12 h1:5BBjfaCv482v3nltlS0u6wH1xJaxjR6ofDrWttNvROg=
+github.com/tdewolff/parse/v2 v2.8.12/go.mod h1:Hwlni2tiVNKyzR1o6nUs4FOF07URA+JLBLd6dlIXYqo=
+github.com/tdewolff/test v1.0.11 h1:FdLbwQVHxqG16SlkGveC0JVyrJN62COWTRyUFzfbtBE=
+github.com/tdewolff/test v1.0.11/go.mod h1:XPuWBzvdUzhCuxWO1ojpXsyzsA5bFoS3tO/Q3kFuTG8=
 github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fxg=
 github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=

--- a/sectool/js/flags.go
+++ b/sectool/js/flags.go
@@ -1,0 +1,44 @@
+package js
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+// Parse handles the "sectool js" command.
+func Parse(args []string, mcpURL string) error {
+	fs := pflag.NewFlagSet("js", pflag.ContinueOnError)
+
+	fs.Usage = func() {
+		_, _ = fmt.Fprint(os.Stderr, `Usage: sectool js <flow_id>
+
+Extract the API surface from a JavaScript or HTML response flow.
+
+Returns deduplicated endpoints, routes, WebSocket URLs, URL literals, and
+external <script src=...> URLs. Inline <script> blocks in HTML responses are
+parsed independently. Endpoints include a last_flow reference to the most
+recent matching proxy flow when one exists.
+
+Arguments:
+  <flow_id>    Flow ID (from proxy, replay, or crawl)
+
+Examples:
+  sectool js f7k2x
+`)
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	posArgs := fs.Args()
+	if len(posArgs) < 1 {
+		fs.Usage()
+		return errors.New("flow_id required: sectool js <flow_id>")
+	}
+
+	return run(mcpURL, posArgs[0])
+}

--- a/sectool/js/js.go
+++ b/sectool/js/js.go
@@ -1,0 +1,93 @@
+package js
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+
+	"github.com/go-appsec/toolbox/sectool/cliutil"
+	"github.com/go-appsec/toolbox/sectool/mcpclient"
+)
+
+func run(mcpURL, flowID string) error {
+	ctx := context.Background()
+
+	client, err := mcpclient.Connect(ctx, mcpURL)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	resp, err := client.JSAnalyze(ctx, flowID)
+	if err != nil {
+		return fmt.Errorf("js_analyze failed: %w", err)
+	}
+
+	fmt.Printf("%s\n\n", cliutil.Bold("JS Analyze"))
+	fmt.Printf("Flow %s, source=%s\n", cliutil.ID(flowID), resp.Source)
+	fmt.Printf("Bytes=%d, script_blocks=%d, parse_errors=%d\n\n",
+		resp.Stats.InputBytes, resp.Stats.ScriptBlocks, resp.Stats.ParseErrors)
+
+	for _, w := range resp.Warnings {
+		fmt.Printf("  %s %s\n", cliutil.Warning("!"), w)
+	}
+	if len(resp.Warnings) > 0 {
+		fmt.Println()
+	}
+
+	if len(resp.Endpoints) > 0 {
+		fmt.Printf("%s\n", cliutil.Bold("Endpoints"))
+		t := cliutil.NewTable(nil)
+		t.AppendHeader(table.Row{"Method", "URL", "Lib", "Last Flow"})
+		for _, e := range resp.Endpoints {
+			t.AppendRow(table.Row{e.Method, e.URL, e.Library, e.LastFlow})
+		}
+		t.Render()
+		fmt.Println()
+	}
+
+	if len(resp.Routes) > 0 {
+		fmt.Printf("%s\n", cliutil.Bold("Routes"))
+		t := cliutil.NewTable(nil)
+		t.AppendHeader(table.Row{"Path", "Framework"})
+		for _, r := range resp.Routes {
+			t.AppendRow(table.Row{r.Path, r.Framework})
+		}
+		t.Render()
+		fmt.Println()
+	}
+
+	if len(resp.Secrets) > 0 {
+		fmt.Printf("%s\n", cliutil.Bold("Secrets"))
+		t := cliutil.NewTable(nil)
+		t.AppendHeader(table.Row{"Kind", "Value"})
+		for _, s := range resp.Secrets {
+			t.AppendRow(table.Row{s.Kind, s.Value})
+		}
+		t.Render()
+		fmt.Println()
+	}
+
+	if len(resp.ExternalScripts) > 0 {
+		fmt.Printf("%s\n", cliutil.Bold("External Scripts"))
+		for _, s := range resp.ExternalScripts {
+			fmt.Printf("  %s\n", s)
+		}
+		fmt.Println()
+	}
+
+	if len(resp.SourceMaps) > 0 {
+		fmt.Printf("%s\n", cliutil.Bold("Source Maps"))
+		for _, s := range resp.SourceMaps {
+			fmt.Printf("  %s\n", s)
+		}
+		fmt.Println()
+	}
+
+	if len(resp.Endpoints)+len(resp.Routes)+len(resp.Secrets)+len(resp.ExternalScripts) == 0 {
+		fmt.Println("No API surface extracted.")
+	}
+
+	return nil
+}

--- a/sectool/main.go
+++ b/sectool/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-appsec/toolbox/sectool/diff"
 	"github.com/go-appsec/toolbox/sectool/encoding"
 	"github.com/go-appsec/toolbox/sectool/hash"
+	"github.com/go-appsec/toolbox/sectool/js"
 	"github.com/go-appsec/toolbox/sectool/jwt"
 	"github.com/go-appsec/toolbox/sectool/oast"
 	"github.com/go-appsec/toolbox/sectool/proxy"
@@ -64,7 +65,7 @@ func main() {
 		return
 
 	// Commands that need MCP client
-	case "proxy", "replay", "oast", "crawl", "diff", "reflected":
+	case "proxy", "replay", "oast", "crawl", "diff", "reflected", "js":
 		var mcpURL string
 		mcpURL, err = getMCPURL(globalFlags)
 		if err != nil {
@@ -84,10 +85,12 @@ func main() {
 			err = diff.Parse(args[1:], mcpURL)
 		case "reflected":
 			err = reflected.Parse(args[1:], mcpURL)
+		case "js":
+			err = js.Parse(args[1:], mcpURL)
 		}
 
 	default:
-		validCommands := []string{"mcp", "proxy", "replay", "oast", "crawl", "diff", "reflected", "encode", "decode", "hash", "jwt", "version", "help"}
+		validCommands := []string{"mcp", "proxy", "replay", "oast", "crawl", "diff", "reflected", "js", "encode", "decode", "hash", "jwt", "version", "help"}
 		err = cliutil.UnknownCommandError(args[0], validCommands)
 	}
 
@@ -128,6 +131,7 @@ Commands:
   crawl      Web crawler for URL and form discovery
   diff       Compare two captured flows
   reflected  Detect reflected parameters in a flow
+  js         Extract API surface from a JavaScript or HTML flow
   encode     Encode strings (url, base64, html)
   decode     Decode strings (url, base64, html)
   hash       Compute hash digests (md5, sha1, sha256, sha512)

--- a/sectool/mcpclient/tools.go
+++ b/sectool/mcpclient/tools.go
@@ -492,3 +492,13 @@ func (c *Client) FindReflected(ctx context.Context, flowID string) (*protocol.Fi
 	}
 	return &resp, nil
 }
+
+// JSAnalyze calls js_analyze and returns the extracted JS/HTML API surface.
+func (c *Client) JSAnalyze(ctx context.Context, flowID string) (*protocol.JSAnalyzeResponse, error) {
+	args := map[string]interface{}{"flow_id": flowID}
+	var resp protocol.JSAnalyzeResponse
+	if err := c.CallToolJSON(ctx, "js_analyze", args, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/sectool/protocol/types.go
+++ b/sectool/protocol/types.go
@@ -518,6 +518,51 @@ type Reflection struct {
 }
 
 // =============================================================================
+// JS Analyze Types
+// =============================================================================
+
+// JSAnalyzeResponse is the response for js_analyze.
+type JSAnalyzeResponse struct {
+	Source          string              `json:"source"` // "javascript" | "html-inline" | "html"
+	Stats           JSAnalyzeStats      `json:"stats"`
+	Endpoints       []ExtractedEndpoint `json:"endpoints,omitempty"`
+	Routes          []ExtractedRoute    `json:"routes,omitempty"`
+	Secrets         []ExtractedSecret   `json:"secrets,omitempty"`
+	ExternalScripts []string            `json:"external_scripts,omitempty"`
+	SourceMaps      []string            `json:"source_maps,omitempty"`
+	Warnings        []string            `json:"warnings,omitempty"`
+}
+
+// JSAnalyzeStats summarizes parse-time metrics.
+type JSAnalyzeStats struct {
+	InputBytes   int `json:"input_bytes"`
+	ScriptBlocks int `json:"script_blocks,omitempty"`
+	ParseErrors  int `json:"parse_errors,omitempty"`
+}
+
+// ExtractedEndpoint is a URL referenced by JS code: a call site, a WebSocket
+// argument, or a bare URL-shaped literal. Library names the origin and doubles
+// as a confidence signal, where "literal" is the weakest.
+type ExtractedEndpoint struct {
+	Method   string `json:"method,omitempty"`    // GET/POST/... if statically determinable
+	URL      string `json:"url"`                 // template form; preserves ${...} placeholders
+	Library  string `json:"library,omitempty"`   // "fetch" | "xhr" | "axios" | "jquery" | "navigation" | "websocket" | "eventsource" | "beacon" | "import" | "literal"
+	LastFlow string `json:"last_flow,omitempty"` // most recent proxy flow_id matching the URL
+}
+
+// ExtractedRoute is a client-side route definition.
+type ExtractedRoute struct {
+	Path      string `json:"path"`
+	Framework string `json:"framework,omitempty"` // "react-router" | "vue-router" | "angular-router"
+}
+
+// ExtractedSecret is a high-precision credential pattern found in source.
+type ExtractedSecret struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}
+
+// =============================================================================
 // Note Types
 // =============================================================================
 

--- a/sectool/service/httputil.go
+++ b/sectool/service/httputil.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -109,8 +110,8 @@ func aggregateByTuple[T any](entries []T, extract func(T) (host, path, method st
 			Count:  count,
 		})
 	}
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Count > result[j].Count
+	slices.SortFunc(result, func(a, b protocol.SummaryEntry) int {
+		return cmp.Compare(b.Count, a.Count)
 	})
 
 	return result

--- a/sectool/service/js/analyze.go
+++ b/sectool/service/js/analyze.go
@@ -1,0 +1,84 @@
+package js
+
+import "github.com/go-appsec/toolbox/sectool/protocol"
+
+// Source labels for the response.
+const (
+	SourceJavaScript = "javascript"
+	SourceHTMLInline = "html-inline"
+	SourceHTML       = "html"
+)
+
+// Result is the deduplicated extraction plus parse-state metadata.
+type Result struct {
+	Source          string
+	ScriptBlocks    int
+	ParseErrors     int
+	Endpoints       []protocol.ExtractedEndpoint
+	Routes          []protocol.ExtractedRoute
+	Secrets         []protocol.ExtractedSecret
+	ExternalScripts []string
+	SourceMaps      []string
+	Warnings        []string
+}
+
+// AnalyzeJS analyzes a JavaScript bundle body.
+func AnalyzeJS(src []byte) Result {
+	res := analyzeBlocks([][]byte{src})
+	res.Source = SourceJavaScript
+	return res
+}
+
+// AnalyzeHTML extracts inline <script> blocks and external <script src=...> URLs from src.
+func AnalyzeHTML(src []byte) Result {
+	scripts := ParseHTMLScripts(src)
+	res := analyzeBlocks(scripts.Inline)
+	res.ExternalScripts = append(res.ExternalScripts, scripts.External...)
+	if len(scripts.Inline) > 0 {
+		res.Source = SourceHTMLInline
+	} else {
+		res.Source = SourceHTML
+	}
+	return res
+}
+
+func analyzeBlocks(blocks [][]byte) Result {
+	var (
+		merged     Extracted
+		secrets    []protocol.ExtractedSecret
+		errors     int
+		blocksUsed int
+	)
+
+	for _, src := range blocks {
+		if len(src) == 0 {
+			continue
+		}
+
+		blocksUsed++
+		pr := parseSource(src)
+		if pr.err != nil {
+			errors++
+		}
+		ext, literals := extractFromSource(src, pr.ast)
+		merged.Endpoints = append(merged.Endpoints, ext.Endpoints...)
+		merged.Routes = append(merged.Routes, ext.Routes...)
+		merged.SourceMaps = append(merged.SourceMaps, ext.SourceMaps...)
+		secrets = append(secrets, extractSecrets(src, literals)...)
+	}
+
+	d := dedupeExtracted(merged)
+
+	r := Result{
+		ScriptBlocks: blocksUsed,
+		ParseErrors:  errors,
+		Endpoints:    d.Endpoints,
+		Routes:       d.Routes,
+		Secrets:      dedupeSecrets(secrets),
+		SourceMaps:   d.SourceMaps,
+	}
+	if errors > 0 {
+		r.Warnings = append(r.Warnings, "JS parser reported errors; extraction may be incomplete")
+	}
+	return r
+}

--- a/sectool/service/js/analyze_test.go
+++ b/sectool/service/js/analyze_test.go
@@ -1,0 +1,625 @@
+package js
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnalyzeJS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("endpoint_and_route_extraction", func(t *testing.T) {
+		cases := []struct {
+			name string
+			src  string
+			// "<library> <method> <url>" for endpoints (method "" elided after space split).
+			endpoints []string
+			routes    []string
+		}{
+			{
+				name: "fetch_basic",
+				src:  `fetch('/api/users');`,
+				endpoints: []string{
+					"fetch  /api/users",
+				},
+			},
+			{
+				name: "fetch_with_method",
+				src:  `fetch('/api/users', {method: 'POST'});`,
+				endpoints: []string{
+					"fetch POST /api/users",
+				},
+			},
+			{
+				name: "axios_methods",
+				src: `
+axios.get('/a/x');
+axios.post('/b/x');
+axios.delete('/c/x');
+`,
+				endpoints: []string{
+					"axios GET /a/x",
+					"axios POST /b/x",
+					"axios DELETE /c/x",
+				},
+			},
+			{
+				name: "axios_bare_call",
+				src:  `axios('/api/x');`,
+				endpoints: []string{
+					"axios  /api/x",
+				},
+			},
+			{
+				name: "axios_bare_call_with_config",
+				src:  `axios('/api/x', {method: 'put'});`,
+				endpoints: []string{
+					"axios PUT /api/x",
+				},
+			},
+			{
+				name: "axios_config_object",
+				src:  `axios({url: '/api/y', method: 'post'});`,
+				endpoints: []string{
+					"axios POST /api/y",
+				},
+			},
+			{
+				name: "axios_config_object_no_method",
+				src:  `axios({url: '/api/z'});`,
+				endpoints: []string{
+					"axios  /api/z",
+				},
+			},
+			{
+				name: "xhr_open",
+				src: `
+var xhr = new XMLHttpRequest();
+xhr.open('PUT', '/api/save');
+`,
+				endpoints: []string{"xhr PUT /api/save"},
+			},
+			{
+				name: "xhr_open_window_prefix",
+				src: `
+var xhr = new window.XMLHttpRequest();
+xhr.open('GET', '/api/g');
+`,
+				endpoints: []string{"xhr GET /api/g"},
+			},
+			{
+				name: "xhr_open_assign",
+				src: `
+let xhr;
+xhr = new XMLHttpRequest();
+xhr.open('POST', '/api/p');
+`,
+				endpoints: []string{"xhr POST /api/p"},
+			},
+			{
+				name: "open_without_xhr_binding",
+				src:  `cache.open('GET', '/api/x');`,
+				endpoints: []string{
+					// /api/x is still picked up as a URL-shaped literal, but not as xhr.
+					"literal  /api/x",
+				},
+			},
+			{
+				name: "open_mis_bound_xhr",
+				src: `
+let xhr = somethingElse();
+xhr.open('GET', '/api/x');
+`,
+				endpoints: []string{
+					"literal  /api/x",
+				},
+			},
+			{
+				name: "jquery_ajax_config",
+				src:  `$.ajax({url: '/api/x', method: 'POST'});`,
+				endpoints: []string{
+					"jquery POST /api/x",
+				},
+			},
+			{
+				name: "websocket",
+				src:  `new WebSocket('wss://example.com/ws');`,
+				endpoints: []string{
+					"websocket  wss://example.com/ws",
+				},
+			},
+			{
+				name:      "websocket_rejects_non_url",
+				src:       `new WebSocket('notaurl');`,
+				endpoints: nil,
+			},
+			{
+				name: "websocket_rejects_relative",
+				src:  `new WebSocket('/socket');`,
+				// /socket is rejected as a WebSocket URL (no ws/wss scheme); the
+				// token scan still picks it up as a generic literal.
+				endpoints: []string{"literal  /socket"},
+			},
+			{
+				name: "navigation_assign",
+				src:  `window.location.href = '/login';`,
+				endpoints: []string{
+					"navigation  /login",
+				},
+			},
+			{
+				name: "location_assign_call",
+				src:  `window.location.assign('/login');`,
+				endpoints: []string{
+					"navigation  /login",
+				},
+			},
+			{
+				name: "location_replace_bare",
+				src:  `location.replace('/home');`,
+				endpoints: []string{
+					"navigation  /home",
+				},
+			},
+			{
+				name: "document_location_assign",
+				src:  `document.location.assign('/d');`,
+				endpoints: []string{
+					"navigation  /d",
+				},
+			},
+			{
+				name: "globalthis_location_assign",
+				src:  `globalThis.location.assign('/gt');`,
+				endpoints: []string{
+					"navigation  /gt",
+				},
+			},
+			{
+				name: "globalthis_location_href",
+				src:  `globalThis.location.href = '/gt-href';`,
+				endpoints: []string{
+					"navigation  /gt-href",
+				},
+			},
+			{
+				name: "string_replace_not_navigation",
+				src:  `var s = 'a'; s.replace('/x/y', 'z');`,
+				endpoints: []string{
+					// receiver is not a location object: /x/y is only a URL-shaped literal.
+					"literal  /x/y",
+				},
+			},
+			{
+				name: "eventsource",
+				src:  `new EventSource('/sse/stream');`,
+				endpoints: []string{
+					"eventsource  /sse/stream",
+				},
+			},
+			{
+				name: "send_beacon",
+				src:  `navigator.sendBeacon('/analytics', data);`,
+				endpoints: []string{
+					"beacon POST /analytics",
+				},
+			},
+			{
+				name: "dynamic_import_relative",
+				src:  `import('./routes/Foo.js');`,
+				endpoints: []string{
+					"import  ./routes/Foo.js",
+				},
+			},
+			{
+				name:      "dynamic_import_bare_module_rejected",
+				src:       `import('lodash');`,
+				endpoints: nil,
+			},
+			{
+				name: "import_scripts",
+				src:  `importScripts('/js/worker.js');`,
+				endpoints: []string{
+					"import  /js/worker.js",
+				},
+			},
+			{
+				name: "import_scripts_multiple",
+				src:  `importScripts('a.js', 'b.js');`,
+				endpoints: []string{
+					"import  a.js",
+					"import  b.js",
+				},
+			},
+			{
+				name: "template_literal_interpolation",
+				src:  "fetch(`/api/users/${id}`);",
+				endpoints: []string{
+					"fetch  /api/users/${...}",
+				},
+			},
+			{
+				name: "url_literal_outside_sink",
+				src:  `var endpoints = ['/api/foo', '/api/bar'];`,
+				endpoints: []string{
+					"literal  /api/foo",
+					"literal  /api/bar",
+				},
+			},
+			{
+				name: "protocol_relative_url_literal",
+				src:  `var s = "//cdn.example.com/bundle.js";`,
+				endpoints: []string{
+					"literal  //cdn.example.com/bundle.js",
+				},
+			},
+			{
+				name:      "bare_identifier_rejected",
+				src:       `var x = 'foo'; var y = 'helloWorld';`,
+				endpoints: nil,
+			},
+			{
+				name:      "ignores_unrelated_string",
+				src:       `var msg = 'hello world';`,
+				endpoints: nil,
+			},
+			{
+				name: "window_fetch",
+				src:  `window.fetch('/api/global');`,
+				endpoints: []string{
+					"fetch  /api/global",
+				},
+			},
+			{
+				name: "globalthis_websocket",
+				src:  `new globalThis.WebSocket('wss://a/b');`,
+				endpoints: []string{
+					"websocket  wss://a/b",
+				},
+			},
+			{
+				name: "self_websocket",
+				src:  `new self.WebSocket('wss://x/y');`,
+				endpoints: []string{
+					"websocket  wss://x/y",
+				},
+			},
+			{
+				name: "relative_path_accepted",
+				src:  `fetch('api/x');`,
+				endpoints: []string{
+					"fetch  api/x",
+				},
+			},
+			{
+				name: "dot_relative_path_accepted",
+				src:  `axios.get('./api/x');`,
+				endpoints: []string{
+					"axios GET ./api/x",
+				},
+			},
+			{
+				name:      "non_url_literal_rejected",
+				src:       `fetch('hello world'); axios.get('translation.key');`,
+				endpoints: nil,
+			},
+			{
+				name: "array_push_not_route",
+				src:  `var a = []; a.push('/x/y');`,
+				endpoints: []string{
+					"literal  /x/y",
+				},
+			},
+			{
+				name: "history_push_with_import",
+				src: `
+import { useHistory } from 'react-router-dom';
+const history = useHistory();
+history.push('/login');
+`,
+				routes: []string{
+					"/login",
+				},
+			},
+			{
+				name: "navigate_call_with_import",
+				src: `
+import { useNavigate } from 'react-router';
+const navigate = useNavigate();
+navigate('/dashboard');
+`,
+				routes: []string{
+					"/dashboard",
+				},
+			},
+			{
+				name: "router_push_vue_with_import",
+				src: `
+import { useRouter } from 'vue-router';
+const router = useRouter();
+router.push('/users');
+`,
+				routes: []string{
+					"/users",
+				},
+			},
+			{
+				name: "bare_history_push_rejected",
+				src:  `history.push('/login');`,
+				endpoints: []string{
+					// Without router-library evidence, the path is only a URL-shaped literal.
+					"literal  /login",
+				},
+			},
+			{
+				name: "create_browser_router",
+				src: `
+const r = createBrowserRouter([
+  { path: '/home', element: H },
+  { path: '/about', element: A },
+]);
+`,
+				routes: []string{"/home", "/about"},
+			},
+			{
+				name: "create_hash_router",
+				src:  `createHashRouter([{path:'/h'}]);`,
+				routes: []string{
+					"/h",
+				},
+			},
+			{
+				name: "vue_router_config",
+				src: `
+const r = createRouter({
+  routes: [
+    { path: '/v1' },
+    { path: '/v2' },
+  ],
+});
+`,
+				routes: []string{"/v1", "/v2"},
+			},
+			{
+				name: "vue_router_constructor",
+				src:  `new VueRouter({ routes: [{ path: '/vv' }] });`,
+				routes: []string{
+					"/vv",
+				},
+			},
+			{
+				name:   "angular_route_config",
+				src:    `RouterModule.forRoot([{ path: '/ang1' }, { path: '/ang2' }]);`,
+				routes: []string{"/ang1", "/ang2"},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				r := AnalyzeJS([]byte(tc.src))
+
+				var gotEndpoints []string
+				for _, e := range r.Endpoints {
+					gotEndpoints = append(gotEndpoints, e.Library+" "+e.Method+" "+e.URL)
+				}
+				assert.ElementsMatch(t, tc.endpoints, gotEndpoints)
+
+				var gotRoutes []string
+				for _, rt := range r.Routes {
+					gotRoutes = append(gotRoutes, rt.Path)
+				}
+				assert.ElementsMatch(t, tc.routes, gotRoutes)
+			})
+		}
+	})
+
+	t.Run("modern_syntax", func(t *testing.T) {
+		src := `
+class C {
+  #x = 1n;
+  m() { return this.#x ?? 0; }
+}
+const a = b?.c ?? d;
+e ||= f;
+import('./mod').then(m => m.run());
+fetch('/api/modern');
+`
+		r := AnalyzeJS([]byte(src))
+		assert.Equal(t, 0, r.ParseErrors)
+		var fetchURLs []string
+		for _, e := range r.Endpoints {
+			if e.Library == libFetch {
+				fetchURLs = append(fetchURLs, e.URL)
+			}
+		}
+		assert.Equal(t, []string{"/api/modern"}, fetchURLs)
+	})
+
+	t.Run("partial_on_parse_error", func(t *testing.T) {
+		src := `fetch('/api/before'); function (`
+		r := AnalyzeJS([]byte(src))
+		assert.Positive(t, r.ParseErrors)
+		assert.NotEmpty(t, r.Warnings)
+		urls := make([]string, 0, len(r.Endpoints))
+		for _, e := range r.Endpoints {
+			urls = append(urls, e.URL)
+		}
+		assert.Contains(t, urls, "/api/before")
+	})
+
+	t.Run("dedupes_endpoints", func(t *testing.T) {
+		src := `
+fetch('/api/x');
+fetch('/api/x');
+axios.get('/api/x');
+`
+		r := AnalyzeJS([]byte(src))
+		urls := make([]string, 0, len(r.Endpoints))
+		for _, e := range r.Endpoints {
+			urls = append(urls, e.Library+" "+e.Method+" "+e.URL)
+		}
+		assert.ElementsMatch(t, []string{
+			"fetch  /api/x",
+			"axios GET /api/x",
+		}, urls)
+	})
+
+	t.Run("literal_yields_to_call_site", func(t *testing.T) {
+		// Same URL appears as a fetch call site AND as a literal in an array.
+		// The endpoint should keep the richer "fetch" library label, not "literal".
+		src := `
+fetch('/api/x');
+var endpoints = ['/api/x', '/api/y'];
+`
+		r := AnalyzeJS([]byte(src))
+		libByURL := map[string]string{}
+		for _, e := range r.Endpoints {
+			libByURL[e.URL] = e.Library
+		}
+		assert.Equal(t, libFetch, libByURL["/api/x"])
+		assert.Equal(t, libLiteral, libByURL["/api/y"])
+	})
+
+	t.Run("cross_collection_dedup", func(t *testing.T) {
+		src := `
+import { useHistory } from 'react-router';
+const history = useHistory();
+fetch('/api/x');
+new WebSocket('wss://example/socket');
+history.push('/route-x');
+var also = ['/api/x', '/route-x', '/lone'];
+`
+		r := AnalyzeJS([]byte(src))
+
+		libByURL := map[string]string{}
+		for _, e := range r.Endpoints {
+			libByURL[e.URL] = e.Library
+		}
+		assert.Equal(t, libFetch, libByURL["/api/x"])
+		assert.Equal(t, libWebSocket, libByURL["wss://example/socket"])
+		assert.Equal(t, libLiteral, libByURL["/lone"])
+		_, hasRouteAsEndpoint := libByURL["/route-x"]
+		assert.False(t, hasRouteAsEndpoint)
+	})
+
+	t.Run("source_map_comment", func(t *testing.T) {
+		src := `var x=1;
+//# sourceMappingURL=app.js.map
+`
+		r := AnalyzeJS([]byte(src))
+		assert.Equal(t, []string{"app.js.map"}, r.SourceMaps)
+	})
+
+	t.Run("bare_location_href_assignment", func(t *testing.T) {
+		src := `location.href = "https://x.example/y";`
+		r := AnalyzeJS([]byte(src))
+
+		var navURLs []string
+		for _, e := range r.Endpoints {
+			if e.Library == libNavigation {
+				navURLs = append(navURLs, e.URL)
+			}
+		}
+		assert.Equal(t, []string{"https://x.example/y"}, navURLs)
+	})
+
+	t.Run("fetch_with_escaped_slashes", func(t *testing.T) {
+		src := `fetch("\/api\/users\/123");`
+		r := AnalyzeJS([]byte(src))
+
+		var fetched []string
+		for _, e := range r.Endpoints {
+			if e.Library == libFetch {
+				fetched = append(fetched, e.URL)
+			}
+		}
+		assert.Equal(t, []string{"/api/users/123"}, fetched)
+	})
+
+	t.Run("sets_source_label", func(t *testing.T) {
+		r := AnalyzeJS([]byte(`var x = 1;`))
+		assert.Equal(t, SourceJavaScript, r.Source)
+	})
+
+	t.Run("counts_script_block", func(t *testing.T) {
+		r := AnalyzeJS([]byte(`var x = 1;`))
+		assert.Equal(t, 1, r.ScriptBlocks)
+	})
+
+	t.Run("empty_body", func(t *testing.T) {
+		r := AnalyzeJS(nil)
+		assert.Equal(t, SourceJavaScript, r.Source)
+		assert.Equal(t, 0, r.ScriptBlocks)
+		assert.Empty(t, r.Endpoints)
+	})
+}
+
+func TestAnalyzeHTML(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inline_and_external", func(t *testing.T) {
+		src := `<html><head>
+<script src="https://cdn.example/app.js"></script>
+<script type="application/ld+json">{"ignored":"yes","url":"/skip"}</script>
+<script>
+  fetch('/api/from-inline');
+  new WebSocket('wss://ws.example/socket');
+</script>
+</head></html>`
+
+		r := AnalyzeHTML([]byte(src))
+		assert.Equal(t, SourceHTMLInline, r.Source)
+		assert.Equal(t, []string{"https://cdn.example/app.js"}, r.ExternalScripts)
+
+		var fetched, socketed []string
+		for _, e := range r.Endpoints {
+			switch e.Library {
+			case libFetch:
+				fetched = append(fetched, e.URL)
+			case libWebSocket:
+				socketed = append(socketed, e.URL)
+			}
+		}
+		assert.Contains(t, fetched, "/api/from-inline")
+		for _, e := range r.Endpoints {
+			assert.NotEqual(t, "/skip", e.URL)
+		}
+		assert.Equal(t, []string{"wss://ws.example/socket"}, socketed)
+	})
+
+	t.Run("only_external_scripts", func(t *testing.T) {
+		src := `<html><head>
+<script src="/a.js"></script>
+<script src="/b.js"></script>
+</head></html>`
+		r := AnalyzeHTML([]byte(src))
+		assert.Equal(t, SourceHTML, r.Source)
+		assert.Equal(t, []string{"/a.js", "/b.js"}, r.ExternalScripts)
+		assert.Empty(t, r.Endpoints)
+	})
+
+	t.Run("no_scripts", func(t *testing.T) {
+		r := AnalyzeHTML([]byte(`<html><body><p>hi</p></body></html>`))
+		assert.Equal(t, SourceHTML, r.Source)
+		assert.Empty(t, r.ExternalScripts)
+		assert.Empty(t, r.Endpoints)
+	})
+
+	t.Run("multiple_inline_blocks", func(t *testing.T) {
+		src := `<html><head>
+<script>fetch('/a');</script>
+<script>fetch('/b');</script>
+</head></html>`
+		r := AnalyzeHTML([]byte(src))
+		assert.Equal(t, SourceHTMLInline, r.Source)
+		assert.Equal(t, 2, r.ScriptBlocks)
+		var fetched []string
+		for _, e := range r.Endpoints {
+			if e.Library == libFetch {
+				fetched = append(fetched, e.URL)
+			}
+		}
+		assert.ElementsMatch(t, []string{"/a", "/b"}, fetched)
+	})
+}

--- a/sectool/service/js/dedupe.go
+++ b/sectool/service/js/dedupe.go
@@ -1,0 +1,112 @@
+package js
+
+import (
+	"cmp"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/go-analyze/bulk"
+
+	"github.com/go-appsec/toolbox/sectool/protocol"
+)
+
+// dedupeExtracted collapses duplicate endpoints and routes.
+// For endpoints sharing method+url, a concrete call site is preferred over a bare literal.
+func dedupeExtracted(in Extracted) Extracted {
+	return Extracted{
+		Endpoints:  dedupeEndpoints(in.Endpoints),
+		Routes:     dedupeRoutes(in.Routes),
+		SourceMaps: dedupeStrings(in.SourceMaps),
+	}
+}
+
+func dedupeEndpoints(eps []protocol.ExtractedEndpoint) []protocol.ExtractedEndpoint {
+	type key struct{ method, url string }
+	seen := make(map[key]int, len(eps))
+	out := make([]protocol.ExtractedEndpoint, 0, len(eps))
+	for _, e := range eps {
+		k := key{e.Method, e.URL}
+		if idx, ok := seen[k]; ok {
+			if out[idx].Library == libLiteral && e.Library != libLiteral {
+				out[idx] = e
+			}
+			continue
+		}
+		seen[k] = len(out)
+		out = append(out, e)
+	}
+	slices.SortStableFunc(out, func(a, b protocol.ExtractedEndpoint) int {
+		return cmp.Or(cmp.Compare(a.URL, b.URL), cmp.Compare(a.Method, b.Method))
+	})
+	return out
+}
+
+func dedupe[T comparable](in []T) []T {
+	if len(in) == 0 {
+		return in
+	}
+	m := bulk.SliceToSet(in)
+	if len(m) == len(in) {
+		return in
+	}
+	out := bulk.MapKeysSlice(m)
+	return out
+}
+
+func dedupeRoutes(rs []protocol.ExtractedRoute) []protocol.ExtractedRoute {
+	out := dedupe(rs)
+	slices.SortStableFunc(out, func(a, b protocol.ExtractedRoute) int {
+		return cmp.Or(cmp.Compare(a.Path, b.Path), cmp.Compare(a.Framework, b.Framework))
+	})
+	return out
+}
+
+func dedupeStrings(in []string) []string {
+	out := dedupe(in)
+	slices.Sort(out)
+	return out
+}
+
+// dedupeSecrets returns secrets with duplicate (kind, value) pairs removed, sorted by kind then value.
+func dedupeSecrets(in []protocol.ExtractedSecret) []protocol.ExtractedSecret {
+	out := dedupe(in)
+	slices.SortStableFunc(out, func(a, b protocol.ExtractedSecret) int {
+		return cmp.Or(cmp.Compare(a.Kind, b.Kind), cmp.Compare(a.Value, b.Value))
+	})
+	return out
+}
+
+// ClassifyURL returns the host and path+query of an HTTP-shaped URL, or ("", "") for unsupported shapes.
+// Fragments are dropped.
+func ClassifyURL(rawURL string) (host, path string) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", ""
+	}
+	switch u.Scheme {
+	case "", "http", "https":
+		host = u.Host
+	default:
+		return "", ""
+	}
+	path = u.EscapedPath()
+	if path == "" && host != "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "", ""
+	}
+	if u.RawQuery != "" {
+		path = path + "?" + u.RawQuery
+	}
+	return host, path
+}
+
+// StripQuery returns p with the query string removed.
+func StripQuery(p string) string {
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		return p[:i]
+	}
+	return p
+}

--- a/sectool/service/js/dedupe_test.go
+++ b/sectool/service/js/dedupe_test.go
@@ -1,0 +1,214 @@
+package js
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-appsec/toolbox/sectool/protocol"
+)
+
+func TestDedupeEndpoints(t *testing.T) {
+	t.Parallel()
+
+	t.Run("literal_yields_to_call_site", func(t *testing.T) {
+		in := []protocol.ExtractedEndpoint{
+			{URL: "/api/x", Library: libLiteral},
+			{URL: "/api/x", Library: libFetch},
+		}
+		out := dedupeEndpoints(in)
+		assert.Len(t, out, 1)
+		assert.Equal(t, libFetch, out[0].Library)
+	})
+
+	t.Run("call_site_then_literal", func(t *testing.T) {
+		in := []protocol.ExtractedEndpoint{
+			{URL: "/api/x", Library: libFetch},
+			{URL: "/api/x", Library: libLiteral},
+		}
+		out := dedupeEndpoints(in)
+		assert.Len(t, out, 1)
+		assert.Equal(t, libFetch, out[0].Library)
+	})
+
+	t.Run("method_distinguishes", func(t *testing.T) {
+		in := []protocol.ExtractedEndpoint{
+			{URL: "/api/x", Method: "GET", Library: libAxios},
+			{URL: "/api/x", Method: "POST", Library: libAxios},
+		}
+		out := dedupeEndpoints(in)
+		assert.Len(t, out, 2)
+	})
+
+	t.Run("two_call_sites_first_wins", func(t *testing.T) {
+		in := []protocol.ExtractedEndpoint{
+			{URL: "/api/x", Library: libFetch},
+			{URL: "/api/x", Library: libAxios},
+		}
+		out := dedupeEndpoints(in)
+		assert.Len(t, out, 1)
+		// Neither side is "literal", so the first occurrence is retained.
+		assert.Equal(t, libFetch, out[0].Library)
+	})
+
+	t.Run("sorted_by_url_then_method", func(t *testing.T) {
+		in := []protocol.ExtractedEndpoint{
+			{URL: "/b", Method: "POST"},
+			{URL: "/a", Method: "POST"},
+			{URL: "/a", Method: "GET"},
+		}
+		out := dedupeEndpoints(in)
+		assert.Equal(t, []protocol.ExtractedEndpoint{
+			{URL: "/a", Method: "GET"},
+			{URL: "/a", Method: "POST"},
+			{URL: "/b", Method: "POST"},
+		}, out)
+	})
+
+	t.Run("empty_input", func(t *testing.T) {
+		out := dedupeEndpoints(nil)
+		assert.Empty(t, out)
+	})
+}
+
+func TestDedupeRoutes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same_path_and_framework_collapsed", func(t *testing.T) {
+		in := []protocol.ExtractedRoute{
+			{Path: "/x", Framework: frameworkReactRouter},
+			{Path: "/x", Framework: frameworkReactRouter},
+		}
+		out := dedupeRoutes(in)
+		assert.Len(t, out, 1)
+	})
+
+	t.Run("same_path_different_framework_kept", func(t *testing.T) {
+		in := []protocol.ExtractedRoute{
+			{Path: "/x", Framework: frameworkReactRouter},
+			{Path: "/x", Framework: frameworkVueRouter},
+		}
+		out := dedupeRoutes(in)
+		assert.Len(t, out, 2)
+	})
+
+	t.Run("sorted_by_path", func(t *testing.T) {
+		in := []protocol.ExtractedRoute{
+			{Path: "/c"},
+			{Path: "/a"},
+			{Path: "/b"},
+		}
+		out := dedupeRoutes(in)
+		assert.Equal(t, []protocol.ExtractedRoute{
+			{Path: "/a"},
+			{Path: "/b"},
+			{Path: "/c"},
+		}, out)
+	})
+
+	t.Run("empty_input", func(t *testing.T) {
+		out := dedupeRoutes(nil)
+		assert.Empty(t, out)
+	})
+}
+
+func TestDedupeStrings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collapses_duplicates_and_sorts", func(t *testing.T) {
+		out := dedupeStrings([]string{"b.js", "a.js", "b.js"})
+		assert.Equal(t, []string{"a.js", "b.js"}, out)
+	})
+
+	t.Run("already_unique_returns_input", func(t *testing.T) {
+		in := []string{"a", "b"}
+		out := dedupeStrings(in)
+		// Fast path returns the input slice unchanged.
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("empty_input", func(t *testing.T) {
+		assert.Empty(t, dedupeStrings(nil))
+	})
+}
+
+func TestDedupeSecrets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collapses_same_kind_and_value", func(t *testing.T) {
+		in := []protocol.ExtractedSecret{
+			{Kind: "aws_access_key", Value: "AKIAIOSFODNN7EXAMPLE"},
+			{Kind: "aws_access_key", Value: "AKIAIOSFODNN7EXAMPLE"},
+		}
+		out := dedupeSecrets(in)
+		assert.Len(t, out, 1)
+	})
+
+	t.Run("same_kind_different_value_kept", func(t *testing.T) {
+		in := []protocol.ExtractedSecret{
+			{Kind: "aws_access_key", Value: "AKIAIOSFODNN7AAAAAAA"},
+			{Kind: "aws_access_key", Value: "AKIAIOSFODNN7BBBBBBB"},
+		}
+		out := dedupeSecrets(in)
+		assert.Len(t, out, 2)
+	})
+
+	t.Run("sorted_by_kind_then_value", func(t *testing.T) {
+		in := []protocol.ExtractedSecret{
+			{Kind: "github_pat", Value: "ghp_abcdefghijklmnopqrstuvwxyz0123456789"},
+			{Kind: "aws_access_key", Value: "AKIAIOSFODNN7EXAMPLE"},
+		}
+		out := dedupeSecrets(in)
+		assert.Equal(t, "aws_access_key", out[0].Kind)
+		assert.Equal(t, "github_pat", out[1].Kind)
+	})
+
+	t.Run("empty_input", func(t *testing.T) {
+		assert.Empty(t, dedupeSecrets(nil))
+	})
+}
+
+func TestClassifyURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name, in, host, path string
+	}{
+		{"absolute_path", "/api/users", "", "/api/users"},
+		{"absolute_path_with_query", "/api/users?id=1", "", "/api/users?id=1"},
+		{"https_with_path", "https://example.com/api/x", "example.com", "/api/x"},
+		{"https_with_query_and_frag", "https://example.com/api/x?q=1#frag", "example.com", "/api/x?q=1"},
+		{"https_no_path", "https://example.com", "example.com", "/"},
+		{"protocol_relative", "//cdn.example.com/bundle.js", "cdn.example.com", "/bundle.js"},
+		{"http_with_port", "http://example.com:8080/x", "example.com:8080", "/x"},
+		{"non_http_scheme_dropped", "wss://example.com/ws", "", ""},
+		{"bare_relative_dropped", "relative/path", "", ""},
+		{"dot_relative_dropped", "./local", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotHost, gotPath := ClassifyURL(tc.in)
+			assert.Equal(t, tc.host, gotHost)
+			assert.Equal(t, tc.path, gotPath)
+		})
+	}
+}
+
+func TestStripQuery(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name, in, want string
+	}{
+		{"no_query", "/api/users", "/api/users"},
+		{"single_param", "/api/users?id=1", "/api/users"},
+		{"multi_param", "/api/users?id=1&q=2", "/api/users"},
+		{"empty", "", ""},
+		{"only_query", "?only=query", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, StripQuery(tc.in))
+		})
+	}
+}

--- a/sectool/service/js/extract.go
+++ b/sectool/service/js/extract.go
@@ -1,0 +1,726 @@
+package js
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/tdewolff/parse/v2/js"
+
+	"github.com/go-appsec/toolbox/sectool/protocol"
+)
+
+// Library labels for extracted endpoints. libLiteral marks bare string literals;
+// other values indicate a concrete call site or constructor argument.
+const (
+	libFetch       = "fetch"
+	libAxios       = "axios"
+	libXHR         = "xhr"
+	libJQuery      = "jquery"
+	libNavigation  = "navigation"
+	libWebSocket   = "websocket"
+	libEventSource = "eventsource"
+	libBeacon      = "beacon"
+	libImport      = "import"
+	libLiteral     = "literal"
+)
+
+// Frameworks recognized for route extraction.
+const (
+	frameworkReactRouter   = "react-router"
+	frameworkVueRouter     = "vue-router"
+	frameworkAngularRouter = "angular-router"
+)
+
+// Global-object names treated as transparent receivers (window.fetch resolves to fetch).
+const (
+	globalWindow     = "window"
+	globalSelf       = "self"
+	globalGlobalThis = "globalThis"
+	globalDocument   = "document"
+	propLocation     = "location"
+)
+
+// urlPathChars is the RFC 3986 pchar set plus path/query/fragment reserved characters.
+const urlPathChars = `A-Za-z0-9._~%+\-/?#&=:@!*$,;()'\[\]`
+
+// urlLiteralRe matches absolute URLs, protocol-relative, absolute-path, and
+// relative-path-with-slash literals. Bare identifiers and i18n keys are rejected.
+var urlLiteralRe = regexp.MustCompile(
+	`^(?:(?:https?|wss?)://[` + urlPathChars + `]+` +
+		`|//[A-Za-z0-9.\-]+/[` + urlPathChars + `]*` +
+		`|/[` + urlPathChars + `]*` +
+		`|(?:\.{1,2}/)[` + urlPathChars + `]*` +
+		`|[A-Za-z0-9._~\-][` + urlPathChars + `]*/[` + urlPathChars + `]*)$`,
+)
+
+// sourceMapRe captures the URL from a sourceMappingURL comment.
+var sourceMapRe = regexp.MustCompile(`(?m)//[#@]\s*sourceMappingURL=(\S+)`)
+
+// looksLikeURL reports whether s is acceptable as an endpoint URL.
+// Template-literal expansions containing `${...}` placeholders are always accepted.
+func looksLikeURL(s string) bool {
+	return urlLiteralRe.MatchString(s) || strings.Contains(s, "${")
+}
+
+// looksLikeWebSocketURL reports whether s is a valid WebSocket URL (absolute ws:// or wss://).
+func looksLikeWebSocketURL(s string) bool {
+	return strings.HasPrefix(s, "ws://") || strings.HasPrefix(s, "wss://") || strings.Contains(s, "${")
+}
+
+// Extracted is the raw, pre-dedup output of a single source pass.
+type Extracted struct {
+	Endpoints  []protocol.ExtractedEndpoint
+	Routes     []protocol.ExtractedRoute
+	SourceMaps []string
+}
+
+// extractFromSource returns the extracted API surface and the raw string literals from src.
+// The literals are reused by secret detection.
+func extractFromSource(src []byte, ast *js.AST) (Extracted, []string) {
+	var out Extracted
+
+	if ast != nil {
+		s := buildScope(ast)
+		v := &sinkVisitor{out: &out, scope: s}
+		js.Walk(v, ast)
+	}
+
+	literals := scanStringLiterals(src)
+
+	// Token-stream scan catches URL-shaped literals outside known sinks.
+	// Seed the seen set so literals don't duplicate already-classified entries.
+	knownURLs := make(map[string]struct{}, len(out.Endpoints)+len(out.Routes))
+	for _, e := range out.Endpoints {
+		knownURLs[e.URL] = struct{}{}
+	}
+	for _, r := range out.Routes {
+		knownURLs[r.Path] = struct{}{}
+	}
+	for _, lit := range literals {
+		if !urlLiteralRe.MatchString(lit) {
+			continue
+		} else if _, seen := knownURLs[lit]; seen {
+			continue
+		}
+		knownURLs[lit] = struct{}{}
+
+		out.Endpoints = append(out.Endpoints, protocol.ExtractedEndpoint{
+			URL:     lit,
+			Library: libLiteral,
+		})
+	}
+
+	for _, m := range sourceMapRe.FindAllSubmatch(src, -1) {
+		out.SourceMaps = append(out.SourceMaps, string(m[1]))
+	}
+
+	return out, literals
+}
+
+// sinkVisitor walks AST nodes collecting sink-arg endpoints, routes, and sockets.
+type sinkVisitor struct {
+	out   *Extracted
+	scope *scope
+}
+
+func (v *sinkVisitor) Exit(_ js.INode) {}
+
+func (v *sinkVisitor) Enter(n js.INode) js.IVisitor {
+	switch node := n.(type) {
+	case *js.CallExpr:
+		v.visitCall(node)
+	case *js.NewExpr:
+		v.visitNew(node)
+	case *js.BinaryExpr:
+		v.visitAssign(node)
+	}
+	return v
+}
+
+// visitCall inspects a call expression's callee shape to identify sinks.
+func (v *sinkVisitor) visitCall(c *js.CallExpr) {
+	if isImportCallee(c.X) {
+		v.captureDynamicImport(c)
+		return
+	}
+	if name, ok := dotObjectName(c.X); ok {
+		v.visitIdentCall(name, c)
+		return
+	}
+	if d, ok := c.X.(*js.DotExpr); ok {
+		v.visitMemberCall(d, c)
+	}
+}
+
+// visitIdentCall handles fetch, router factories, and call-form router navigation.
+func (v *sinkVisitor) visitIdentCall(name string, c *js.CallExpr) {
+	if fw, ok := v.scope.routerReceivers[name]; ok && len(c.Args.List) >= 1 {
+		if route, rok := routeFromArg(c.Args.List[0].Value); rok {
+			v.out.Routes = append(v.out.Routes, protocol.ExtractedRoute{
+				Path:      route,
+				Framework: fw,
+			})
+		}
+	}
+	switch name {
+	case "fetch":
+		v.captureFetch(c)
+	case "axios":
+		v.captureAxiosCall(c)
+	case "importScripts":
+		v.captureImportScripts(c)
+	case "createBrowserRouter", "createHashRouter", "createMemoryRouter":
+		if len(c.Args.List) >= 1 {
+			v.captureRouteArray(c.Args.List[0].Value, frameworkReactRouter)
+		}
+	case "createRouter":
+		if len(c.Args.List) >= 1 {
+			v.captureRouteConfigObject(c.Args.List[0].Value, frameworkVueRouter)
+		}
+	}
+}
+
+// captureFetch appends an endpoint for a `fetch(url, [opts])` call.
+func (v *sinkVisitor) captureFetch(c *js.CallExpr) {
+	if len(c.Args.List) == 0 {
+		return
+	}
+	url, ok := staticString(c.Args.List[0].Value)
+	if !ok || !looksLikeURL(url) {
+		return
+	}
+	ep := protocol.ExtractedEndpoint{
+		URL:     url,
+		Library: libFetch,
+	}
+	if len(c.Args.List) >= 2 {
+		ep.Method = methodFromOptionsArg(c.Args.List[1].Value)
+	}
+	v.out.Endpoints = append(v.out.Endpoints, ep)
+}
+
+// captureAxiosCall handles the axios(url[, opts]) and axios({url, method}) direct-call forms.
+// The axios.<method>() shortcuts are handled by visitAxiosCall.
+func (v *sinkVisitor) captureAxiosCall(c *js.CallExpr) {
+	if len(c.Args.List) == 0 {
+		return
+	}
+	first := c.Args.List[0].Value
+	if u, ok := staticString(first); ok {
+		if !looksLikeURL(u) {
+			return
+		}
+		ep := protocol.ExtractedEndpoint{URL: u, Library: libAxios}
+		if len(c.Args.List) >= 2 {
+			ep.Method = methodFromOptionsArg(c.Args.List[1].Value)
+		}
+		v.out.Endpoints = append(v.out.Endpoints, ep)
+		return
+	}
+	if obj, ok := first.(*js.ObjectExpr); ok {
+		u := stringProp(obj, "url")
+		if u == "" || !looksLikeURL(u) {
+			return
+		}
+		v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+			Method:  strings.ToUpper(stringProp(obj, "method")),
+			URL:     u,
+			Library: libAxios,
+		})
+	}
+}
+
+// captureDynamicImport handles dynamic import('...') calls. Only path- or URL-shaped
+// specifiers are captured; bare module (npm package) names are ignored.
+func (v *sinkVisitor) captureDynamicImport(c *js.CallExpr) {
+	if len(c.Args.List) == 0 {
+		return
+	}
+	if u, ok := staticString(c.Args.List[0].Value); ok && importSpecifierIsPath(u) {
+		v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+			URL:     u,
+			Library: libImport,
+		})
+	}
+}
+
+// captureImportScripts handles importScripts(url, ...) worker script loads.
+// Every static string argument is a script URL by API contract.
+func (v *sinkVisitor) captureImportScripts(c *js.CallExpr) {
+	for _, arg := range c.Args.List {
+		if u, ok := staticString(arg.Value); ok && u != "" {
+			v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+				URL:     u,
+				Library: libImport,
+			})
+		}
+	}
+}
+
+// visitMemberCall handles `<obj>.<prop>(...)` shaped sinks.
+func (v *sinkVisitor) visitMemberCall(d *js.DotExpr, c *js.CallExpr) {
+	prop, ok := dotPropertyName(d.Y)
+	if !ok {
+		return
+	}
+
+	// (window|document|self).location.assign|replace(url) and bare location.assign(...)
+	if (prop == "assign" || prop == "replace") && isLocationObject(d.X) {
+		v.captureNavURL(c)
+		return
+	}
+
+	objName, ok := dotObjectName(d.X)
+	if !ok {
+		return
+	}
+
+	switch objName {
+	case "axios":
+		v.visitAxiosCall(prop, c)
+	case "$", "jQuery":
+		v.visitJQueryCall(prop, c)
+	}
+
+	// (window|self|globalThis).fetch(...) treated as fetch sink
+	if prop == "fetch" && isGlobalThisName(objName) {
+		v.captureFetch(c)
+	}
+
+	// window.open(url, ...)
+	if (objName == globalWindow || objName == globalSelf) && prop == "open" {
+		v.captureNavURL(c)
+	}
+
+	// navigator.sendBeacon(url, data) — always a POST
+	if objName == "navigator" && prop == "sendBeacon" && len(c.Args.List) >= 1 {
+		if u, ok := staticString(c.Args.List[0].Value); ok && looksLikeURL(u) {
+			v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+				Method:  "POST",
+				URL:     u,
+				Library: libBeacon,
+			})
+		}
+	}
+
+	// XMLHttpRequest.open(method, url, ...); receiver must be bound to `new XMLHttpRequest()`
+	if prop == "open" && len(c.Args.List) >= 2 {
+		if _, isXHR := v.scope.xhrReceivers[objName]; isXHR {
+			if m, mok := staticString(c.Args.List[0].Value); mok {
+				if u, uok := staticString(c.Args.List[1].Value); uok && looksLikeURL(u) {
+					v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+						Method:  strings.ToUpper(m),
+						URL:     u,
+						Library: libXHR,
+					})
+				}
+			}
+		}
+	}
+
+	// Router navigation: <router-receiver>.push/replace(arg)
+	if prop == "push" || prop == "replace" {
+		if fw, ok := v.scope.routerReceivers[objName]; ok && len(c.Args.List) >= 1 {
+			if route, rok := routeFromArg(c.Args.List[0].Value); rok {
+				v.out.Routes = append(v.out.Routes, protocol.ExtractedRoute{
+					Path:      route,
+					Framework: fw,
+				})
+			}
+		}
+	}
+
+	// Vue Router constructor `new VueRouter({routes: [...]})` is handled by visitNew.
+	// Angular RouterModule.forRoot([...]) / forChild([...]).
+	if objName == "RouterModule" && (prop == "forRoot" || prop == "forChild") && len(c.Args.List) >= 1 {
+		v.captureRouteArray(c.Args.List[0].Value, frameworkAngularRouter)
+	}
+}
+
+// visitAxiosCall handles axios.<method>() shortcuts (get/post/put/delete/patch/head/options).
+func (v *sinkVisitor) visitAxiosCall(method string, c *js.CallExpr) {
+	upper := strings.ToUpper(method)
+	switch upper {
+	case "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS":
+	default:
+		return
+	}
+	if len(c.Args.List) == 0 {
+		return
+	}
+	u, ok := staticString(c.Args.List[0].Value)
+	if !ok || !looksLikeURL(u) {
+		return
+	}
+	v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+		Method:  upper,
+		URL:     u,
+		Library: libAxios,
+	})
+}
+
+// visitJQueryCall handles $.ajax / $.get / $.post / $.getJSON.
+func (v *sinkVisitor) visitJQueryCall(method string, c *js.CallExpr) {
+	if len(c.Args.List) == 0 {
+		return
+	}
+	var url string
+	var ok bool
+	var m string
+
+	switch strings.ToLower(method) {
+	case "get", "getjson":
+		m = "GET"
+		url, ok = staticString(c.Args.List[0].Value)
+	case "post":
+		m = "POST"
+		url, ok = staticString(c.Args.List[0].Value)
+	case "ajax":
+		if obj, isObj := c.Args.List[0].Value.(*js.ObjectExpr); isObj {
+			url = stringProp(obj, "url")
+			m = strings.ToUpper(stringProp(obj, "method"))
+			if m == "" {
+				m = strings.ToUpper(stringProp(obj, "type"))
+			}
+			ok = url != ""
+		}
+	default:
+		return
+	}
+	if !ok || !looksLikeURL(url) {
+		return
+	}
+	v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+		Method:  m,
+		URL:     url,
+		Library: libJQuery,
+	})
+}
+
+// visitNew handles `new WebSocket(url, ...)` and `new VueRouter({routes:[...]})`.
+func (v *sinkVisitor) visitNew(n *js.NewExpr) {
+	name, ok := constructorName(n.X)
+	if !ok {
+		return
+	}
+	switch name {
+	case "WebSocket":
+		if n.Args == nil || len(n.Args.List) == 0 {
+			return
+		}
+		if u, ok := staticString(n.Args.List[0].Value); ok && looksLikeWebSocketURL(u) {
+			v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+				URL:     u,
+				Library: libWebSocket,
+			})
+		}
+	case "EventSource":
+		if n.Args == nil || len(n.Args.List) == 0 {
+			return
+		}
+		if u, ok := staticString(n.Args.List[0].Value); ok && looksLikeURL(u) {
+			v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+				URL:     u,
+				Library: libEventSource,
+			})
+		}
+	case "VueRouter":
+		if n.Args != nil && len(n.Args.List) >= 1 {
+			v.captureRouteConfigObject(n.Args.List[0].Value, frameworkVueRouter)
+		}
+	}
+}
+
+// visitAssign handles `document.location = url` and `window.location.href = url`.
+func (v *sinkVisitor) visitAssign(b *js.BinaryExpr) {
+	if b.Op != js.EqToken {
+		return
+	} else if !isLocationLHS(b.X) {
+		return
+	}
+	if u, ok := staticString(b.Y); ok && looksLikeURL(u) {
+		v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+			URL:     u,
+			Library: libNavigation,
+		})
+	}
+}
+
+// captureRouteArray walks an array-literal argument and pulls `{path: '/x'}`
+// entries as routes for the given framework. Non-array arguments are ignored.
+func (v *sinkVisitor) captureRouteArray(expr js.IExpr, framework string) {
+	arr, ok := expr.(*js.ArrayExpr)
+	if !ok {
+		return
+	}
+	for _, el := range arr.List {
+		if el.Value == nil {
+			continue
+		}
+		obj, ok := el.Value.(*js.ObjectExpr)
+		if !ok {
+			continue
+		}
+		if p := stringProp(obj, "path"); p != "" {
+			v.out.Routes = append(v.out.Routes, protocol.ExtractedRoute{
+				Path:      p,
+				Framework: framework,
+			})
+		}
+	}
+}
+
+// captureRouteConfigObject walks an object literal `{routes: [...]}` argument
+// and pulls each `{path: '/x'}` route entry for the given framework.
+func (v *sinkVisitor) captureRouteConfigObject(expr js.IExpr, framework string) {
+	obj, ok := expr.(*js.ObjectExpr)
+	if !ok {
+		return
+	}
+	for _, p := range obj.List {
+		if p.Name == nil {
+			continue
+		} else if propertyKeyName(p) != "routes" {
+			continue
+		}
+		v.captureRouteArray(p.Value, framework)
+	}
+}
+
+// captureNavURL appends a navigation endpoint for the first static URL argument of c.
+func (v *sinkVisitor) captureNavURL(c *js.CallExpr) {
+	if len(c.Args.List) == 0 {
+		return
+	}
+	if u, ok := staticString(c.Args.List[0].Value); ok && looksLikeURL(u) {
+		v.out.Endpoints = append(v.out.Endpoints, protocol.ExtractedEndpoint{
+			URL:     u,
+			Library: libNavigation,
+		})
+	}
+}
+
+// isGlobalThisName reports whether name refers to the global object.
+func isGlobalThisName(name string) bool {
+	return name == globalWindow || name == globalSelf || name == globalGlobalThis
+}
+
+// isImportCallee reports whether a call expression's callee is the `import` keyword,
+// i.e. a dynamic import() expression.
+func isImportCallee(expr js.IExpr) bool {
+	switch e := expr.(type) {
+	case *js.LiteralExpr:
+		return e.TokenType == js.ImportToken
+	case js.LiteralExpr:
+		return e.TokenType == js.ImportToken
+	}
+	return false
+}
+
+// importSpecifierIsPath reports whether a dynamic-import specifier is a path or URL
+// rather than a bare module (npm package) name.
+func importSpecifierIsPath(s string) bool {
+	return strings.HasPrefix(s, "/") ||
+		strings.HasPrefix(s, "./") ||
+		strings.HasPrefix(s, "../") ||
+		strings.Contains(s, "://")
+}
+
+// isLocationObject reports whether expr refers to a location object:
+// bare `location`, or `(window|document|self|globalThis).location`.
+func isLocationObject(expr js.IExpr) bool {
+	if name, ok := dotObjectName(expr); ok {
+		return name == propLocation
+	}
+	d, ok := expr.(*js.DotExpr)
+	if !ok {
+		return false
+	}
+	prop, ok := dotPropertyName(d.Y)
+	if !ok || prop != propLocation {
+		return false
+	}
+	base, ok := dotObjectName(d.X)
+	return ok && (isGlobalThisName(base) || base == globalDocument)
+}
+
+// constructorName returns the constructor identifier for a `new` expression,
+// unwrapping `window.`/`self.`/`globalThis.` prefixes (e.g. `new window.WebSocket(...)`).
+func constructorName(expr js.IExpr) (string, bool) {
+	if name, ok := dotObjectName(expr); ok {
+		return name, true
+	}
+	if d, ok := expr.(*js.DotExpr); ok {
+		if base, ok := dotObjectName(d.X); !ok || !isGlobalThisName(base) {
+			return "", false
+		}
+		return dotPropertyName(d.Y)
+	}
+	return "", false
+}
+
+// isLocationLHS reports whether expr is an assignment target on a location object
+// (window./document./self. prefix, with or without a .href tail, or bare location.href).
+func isLocationLHS(expr js.IExpr) bool {
+	d, ok := expr.(*js.DotExpr)
+	if !ok {
+		return false
+	}
+	prop, ok := dotPropertyName(d.Y)
+	if !ok {
+		return false
+	}
+
+	if prop == "href" {
+		// Bare `location.href = ...` (no receiver)
+		if v, ok := d.X.(*js.Var); ok {
+			return string(v.Data) == propLocation
+		}
+		inner, ok := d.X.(*js.DotExpr)
+		if !ok {
+			return false
+		}
+		innerProp, ok := dotPropertyName(inner.Y)
+		if !ok || innerProp != propLocation {
+			return false
+		}
+		base, ok := dotObjectName(inner.X)
+		return ok && (isGlobalThisName(base) || base == globalDocument)
+	}
+
+	if prop == propLocation {
+		base, ok := dotObjectName(d.X)
+		return ok && (isGlobalThisName(base) || base == globalDocument)
+	}
+
+	return false
+}
+
+// staticString returns the literal string value of expr when it is statically
+// resolvable: a quoted string literal or a template literal with no expressions.
+func staticString(expr js.IExpr) (string, bool) {
+	switch e := expr.(type) {
+	case *js.LiteralExpr:
+		if e.TokenType == js.StringToken {
+			return unquote(e.Data)
+		}
+	case js.LiteralExpr:
+		if e.TokenType == js.StringToken {
+			return unquote(e.Data)
+		}
+	case *js.TemplateExpr:
+		if e.Tag != nil {
+			return "", false
+		}
+		if len(e.List) == 0 {
+			return unquote(e.Tail)
+		}
+		var b strings.Builder
+		for _, part := range e.List {
+			if s, ok := unquote(part.Value); ok {
+				b.WriteString(s)
+			}
+			b.WriteString("${...}")
+		}
+		if s, ok := unquote(e.Tail); ok {
+			b.WriteString(s)
+		}
+		return b.String(), true
+	}
+	return "", false
+}
+
+// dotObjectName returns the identifier name for the base of a dot/var expression.
+// Handles both pointer and value forms of LiteralExpr because the parser uses both.
+func dotObjectName(expr js.IExpr) (string, bool) {
+	switch e := expr.(type) {
+	case *js.Var:
+		return string(e.Data), true
+	case *js.LiteralExpr:
+		if e.TokenType == js.IdentifierToken {
+			return string(e.Data), true
+		}
+	case js.LiteralExpr:
+		if e.TokenType == js.IdentifierToken {
+			return string(e.Data), true
+		}
+	}
+	return "", false
+}
+
+// dotPropertyName returns the property name on the right of a DotExpr.
+// Handles both pointer and value forms of LiteralExpr because the parser uses both.
+// StringToken data is unquoted so `obj["key"]`-shaped access resolves to `key`.
+func dotPropertyName(expr js.IExpr) (string, bool) {
+	switch e := expr.(type) {
+	case *js.Var:
+		return string(e.Data), true
+	case *js.LiteralExpr:
+		if e.TokenType == js.StringToken {
+			return unquote(e.Data)
+		}
+		return string(e.Data), true
+	case js.LiteralExpr:
+		if e.TokenType == js.StringToken {
+			return unquote(e.Data)
+		}
+		return string(e.Data), true
+	}
+	return "", false
+}
+
+// methodFromOptionsArg pulls a method literal from a fetch options object: `{method: 'POST'}`.
+func methodFromOptionsArg(expr js.IExpr) string {
+	obj, ok := expr.(*js.ObjectExpr)
+	if !ok {
+		return ""
+	}
+	return strings.ToUpper(stringProp(obj, "method"))
+}
+
+// stringProp returns the static string value for an object literal property of the given key.
+func stringProp(obj *js.ObjectExpr, key string) string {
+	for _, p := range obj.List {
+		if p.Name == nil {
+			continue
+		} else if propertyKeyName(p) != key {
+			continue
+		}
+
+		if s, ok := staticString(p.Value); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// propertyKeyName extracts a property's key name from a Property,
+// supporting both identifier and string-literal forms.
+func propertyKeyName(p js.Property) string {
+	if p.Name == nil {
+		return ""
+	}
+	switch p.Name.Literal.TokenType {
+	case js.StringToken:
+		if s, ok := unquote(p.Name.Literal.Data); ok {
+			return s
+		}
+	case js.IdentifierToken:
+		return string(p.Name.Literal.Data)
+	}
+	return ""
+}
+
+// routeFromArg returns the route path argument for Router.push/replace.
+// Accepts a string literal or `{path: '/route'}` object literal.
+func routeFromArg(expr js.IExpr) (string, bool) {
+	if s, ok := staticString(expr); ok && strings.HasPrefix(s, "/") {
+		return s, true
+	}
+	if obj, ok := expr.(*js.ObjectExpr); ok {
+		if p := stringProp(obj, "path"); p != "" {
+			return p, true
+		}
+	}
+	return "", false
+}

--- a/sectool/service/js/extract_test.go
+++ b/sectool/service/js/extract_test.go
@@ -1,0 +1,107 @@
+package js
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLooksLikeURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"https_with_query", "https://example.com/path?q=1", true},
+		{"http_root", "http://example.com/", true},
+		{"wss_path", "wss://ws.example/socket", true},
+		{"protocol_relative", "//cdn.example.com/x.js", true},
+		{"absolute_path", "/api/users", true},
+		{"absolute_path_query", "/api/users?id=1", true},
+		{"dot_relative", "./local", true},
+		{"dot_dot_relative", "../up/over", true},
+		{"bare_relative", "api/users", true},
+		{"asset_relative", "assets/main.js", true},
+		{"template_interpolation", "/api/users/${id}", true},
+		{"plain_text_rejected", "hello world", false},
+		{"i18n_key_rejected", "translation.key", false},
+		{"bare_ident_rejected", "foo", false},
+		{"angle_brackets_rejected", "https://example.com/<script>", false},
+		{"empty_rejected", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, looksLikeURL(tc.in))
+		})
+	}
+}
+
+func TestLooksLikeWebSocketURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"ws_scheme", "ws://x/y", true},
+		{"wss_scheme", "wss://x/y", true},
+		{"ws_template_host", "ws://${host}/sock", true},
+		{"wss_template_path", "wss://example.com/${path}", true},
+		{"bare_text_rejected", "notaurl", false},
+		{"absolute_path_rejected", "/socket", false},
+		{"https_rejected", "https://example.com/", false},
+		{"protocol_relative_rejected", "//cdn/foo", false},
+		{"empty_rejected", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, looksLikeWebSocketURL(tc.in))
+		})
+	}
+}
+
+func TestExtractFromSource(t *testing.T) {
+	t.Parallel()
+
+	t.Run("captures_source_map_url", func(t *testing.T) {
+		src := []byte(`var x=1;
+//# sourceMappingURL=app.js.map`)
+		pr := parseSource(src)
+		got, _ := extractFromSource(src, pr.ast)
+		assert.Equal(t, []string{"app.js.map"}, got.SourceMaps)
+	})
+
+	t.Run("returns_token_literals_for_secrets", func(t *testing.T) {
+		src := []byte(`var k = "secret-value-x";`)
+		_, literals := extractFromSource(src, nil)
+		assert.Contains(t, literals, "secret-value-x")
+	})
+
+	t.Run("ast_nil_still_scans_literals", func(t *testing.T) {
+		// With a nil AST the AST visitor is skipped, but URL-shaped literals
+		// in the token stream still flow into Endpoints as libLiteral entries.
+		src := []byte(`var x = '/api/from-tokens';`)
+		got, _ := extractFromSource(src, nil)
+		assert.Len(t, got.Endpoints, 1)
+		assert.Equal(t, "/api/from-tokens", got.Endpoints[0].URL)
+		assert.Equal(t, libLiteral, got.Endpoints[0].Library)
+	})
+
+	t.Run("token_literal_does_not_duplicate_sink_url", func(t *testing.T) {
+		src := []byte(`fetch('/api/x'); var also = '/api/x';`)
+		pr := parseSource(src)
+		got, _ := extractFromSource(src, pr.ast)
+		// Only the fetch call site should appear; the bare literal must not
+		// add a second /api/x entry.
+		var matches int
+		for _, e := range got.Endpoints {
+			if e.URL == "/api/x" {
+				matches++
+			}
+		}
+		assert.Equal(t, 1, matches)
+	})
+}

--- a/sectool/service/js/html.go
+++ b/sectool/service/js/html.go
@@ -1,0 +1,73 @@
+package js
+
+import (
+	"bytes"
+	"slices"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// HTMLScripts holds the inline blocks and external src URLs extracted from HTML.
+type HTMLScripts struct {
+	Inline   [][]byte
+	External []string
+}
+
+// ParseHTMLScripts walks the HTML document and returns inline <script> bodies
+// and external <script src=...> URLs. Inline blocks are returned in document
+// order so the caller can parse them independently.
+func ParseHTMLScripts(src []byte) HTMLScripts {
+	var out HTMLScripts
+	z := html.NewTokenizer(bytes.NewReader(src))
+
+	var inScript, skipInline bool
+	for {
+		tt := z.Next()
+		switch tt {
+		case html.ErrorToken:
+			return out
+		case html.StartTagToken:
+			name, hasAttr := z.TagName()
+			if string(name) != "script" {
+				continue
+			}
+
+			inScript = true
+			skipInline = false
+			var srcURL string
+			for hasAttr {
+				var k, val []byte
+				k, val, hasAttr = z.TagAttr()
+				switch string(k) {
+				case "src":
+					srcURL = string(val)
+				case "type":
+					// Skip non-JS script blocks (e.g., application/ld+json).
+					t := strings.ToLower(string(val))
+					if t != "" && t != "text/javascript" && t != "application/javascript" && t != "module" {
+						skipInline = true
+					}
+				}
+			}
+			if srcURL != "" {
+				out.External = append(out.External, srcURL)
+				skipInline = true
+			}
+		case html.TextToken:
+			if !inScript || skipInline {
+				continue
+			}
+			text := z.Text()
+			if len(bytes.TrimSpace(text)) > 0 {
+				out.Inline = append(out.Inline, slices.Clone(text))
+			}
+		case html.EndTagToken:
+			name, _ := z.TagName()
+			if string(name) == "script" {
+				inScript = false
+				skipInline = false
+			}
+		}
+	}
+}

--- a/sectool/service/js/html_test.go
+++ b/sectool/service/js/html_test.go
@@ -1,0 +1,88 @@
+package js
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseHTMLScripts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inline_and_external_mixed", func(t *testing.T) {
+		src := []byte(`<html><head>
+<script src="https://cdn.example/app.js"></script>
+<script>fetch('/a');</script>
+<script src="/b.js"></script>
+<script>fetch('/c');</script>
+</head></html>`)
+		got := ParseHTMLScripts(src)
+		assert.Equal(t, []string{"https://cdn.example/app.js", "/b.js"}, got.External)
+		assert.Len(t, got.Inline, 2)
+		assert.Contains(t, string(got.Inline[0]), "fetch('/a')")
+		assert.Contains(t, string(got.Inline[1]), "fetch('/c')")
+	})
+
+	t.Run("ld_json_inline_skipped", func(t *testing.T) {
+		src := []byte(`<html><head>
+<script type="application/ld+json">{"ignored":"yes"}</script>
+<script>fetch('/keep');</script>
+</head></html>`)
+		got := ParseHTMLScripts(src)
+		assert.Empty(t, got.External)
+		assert.Len(t, got.Inline, 1)
+		assert.Contains(t, string(got.Inline[0]), "/keep")
+	})
+
+	t.Run("type_module_kept", func(t *testing.T) {
+		src := []byte(`<script type="module">fetch('/m');</script>`)
+		got := ParseHTMLScripts(src)
+		assert.Len(t, got.Inline, 1)
+		assert.Contains(t, string(got.Inline[0]), "/m")
+	})
+
+	t.Run("type_javascript_kept", func(t *testing.T) {
+		src := []byte(`<script type="text/javascript">fetch('/j');</script>` +
+			`<script type="application/javascript">fetch('/k');</script>`)
+		got := ParseHTMLScripts(src)
+		assert.Len(t, got.Inline, 2)
+	})
+
+	t.Run("src_attr_suppresses_inline", func(t *testing.T) {
+		// Browsers ignore inline content when src= is present.
+		src := []byte(`<script src="/x.js">fetch('/ignored');</script>`)
+		got := ParseHTMLScripts(src)
+		assert.Equal(t, []string{"/x.js"}, got.External)
+		assert.Empty(t, got.Inline)
+	})
+
+	t.Run("whitespace_only_inline_skipped", func(t *testing.T) {
+		src := []byte(`<script>
+		</script>`)
+		got := ParseHTMLScripts(src)
+		assert.Empty(t, got.Inline)
+	})
+
+	t.Run("no_scripts", func(t *testing.T) {
+		got := ParseHTMLScripts([]byte(`<html><body><p>hi</p></body></html>`))
+		assert.Empty(t, got.Inline)
+		assert.Empty(t, got.External)
+	})
+
+	t.Run("malformed_html_tolerated", func(t *testing.T) {
+		// Unclosed tag; tokenizer should still surface the inline content.
+		src := []byte(`<html><head><script>fetch('/mal')`)
+		got := ParseHTMLScripts(src)
+		assert.Len(t, got.Inline, 1)
+		assert.Contains(t, string(got.Inline[0]), "/mal")
+	})
+
+	t.Run("preserves_document_order", func(t *testing.T) {
+		src := []byte(`<script>1</script>x<script>2</script>x<script>3</script>`)
+		got := ParseHTMLScripts(src)
+		assert.Len(t, got.Inline, 3)
+		assert.Equal(t, "1", string(got.Inline[0]))
+		assert.Equal(t, "2", string(got.Inline[1]))
+		assert.Equal(t, "3", string(got.Inline[2]))
+	})
+}

--- a/sectool/service/js/parse.go
+++ b/sectool/service/js/parse.go
@@ -1,0 +1,162 @@
+// Package js extracts API surface (endpoints, routes, WebSocket URLs, URL literals)
+// from JavaScript and HTML responses using the tdewolff/parse JS parser.
+package js
+
+import (
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/tdewolff/parse/v2"
+	"github.com/tdewolff/parse/v2/js"
+)
+
+// parseResult holds the parsed AST and any parse error. AST may be nil on hard failure.
+type parseResult struct {
+	ast *js.AST
+	err error
+}
+
+// parseSource parses a single JS source block. On error the AST may still be nil.
+func parseSource(src []byte) parseResult {
+	input := parse.NewInputBytes(src)
+	ast, err := js.Parse(input, js.Options{})
+	return parseResult{ast: ast, err: err}
+}
+
+// scanStringLiterals returns every string and template literal value in src.
+// Used as a tolerant fallback when AST parsing fails.
+func scanStringLiterals(src []byte) []string {
+	l := js.NewLexer(parse.NewInputBytes(src))
+	var out []string
+	for {
+		tt, data := l.Next()
+		switch tt {
+		case js.ErrorToken:
+			return out
+		case js.StringToken, js.TemplateToken:
+			// TemplateToken covers every template-literal fragment; unquote
+			// handles each delimiter shape (`...`, `...${, }...${, }...`).
+			if s, ok := unquote(data); ok {
+				out = append(out, s)
+			}
+		}
+	}
+}
+
+// unquote strips delimiters from a string or template-literal token's raw data.
+// Returns false if no recognizable delimiters are present.
+func unquote(data []byte) (string, bool) {
+	if len(data) < 2 {
+		return "", false
+	}
+	var start, end int
+	switch data[0] {
+	case '\'', '"':
+		if data[len(data)-1] != data[0] {
+			return "", false
+		}
+		start, end = 1, len(data)-1
+	case '`':
+		start = 1
+		if len(data) >= 3 && data[len(data)-2] == '$' && data[len(data)-1] == '{' {
+			end = len(data) - 2
+		} else if data[len(data)-1] == '`' {
+			end = len(data) - 1
+		} else {
+			return "", false
+		}
+	case '}':
+		start = 1
+		if len(data) >= 3 && data[len(data)-2] == '$' && data[len(data)-1] == '{' {
+			end = len(data) - 2
+		} else if data[len(data)-1] == '`' {
+			end = len(data) - 1
+		} else {
+			return "", false
+		}
+	default:
+		return "", false
+	}
+	if end <= start {
+		return "", false
+	}
+	return decodeJSEscapes(string(data[start:end])), true
+}
+
+// decodeJSEscapes resolves JS string-escape sequences (\n, \t, \xHH, \uHHHH, \u{H..}, etc.).
+// Unknown single-char escapes drop the backslash. Malformed escapes are left as-is.
+func decodeJSEscapes(s string) string {
+	if strings.IndexByte(s, '\\') < 0 {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c != '\\' || i+1 >= len(s) {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		next := s[i+1]
+		switch next {
+		case '/', '\\', '"', '\'', '`':
+			b.WriteByte(next)
+			i += 2
+		case 'n':
+			b.WriteByte('\n')
+			i += 2
+		case 'r':
+			b.WriteByte('\r')
+			i += 2
+		case 't':
+			b.WriteByte('\t')
+			i += 2
+		case 'b':
+			b.WriteByte('\b')
+			i += 2
+		case 'f':
+			b.WriteByte('\f')
+			i += 2
+		case 'v':
+			b.WriteByte('\v')
+			i += 2
+		case '0':
+			b.WriteByte(0)
+			i += 2
+		case 'x':
+			if i+4 <= len(s) {
+				if v, err := strconv.ParseUint(s[i+2:i+4], 16, 8); err == nil {
+					b.WriteByte(byte(v))
+					i += 4
+					continue
+				}
+			}
+			b.WriteByte(c)
+			i++
+		case 'u':
+			if i+2 < len(s) && s[i+2] == '{' {
+				if end := strings.IndexByte(s[i+3:], '}'); end > 0 && end <= 6 {
+					if v, err := strconv.ParseUint(s[i+3:i+3+end], 16, 32); err == nil && v <= utf8.MaxRune {
+						b.WriteRune(rune(v))
+						i += 4 + end
+						continue
+					}
+				}
+			} else if i+6 <= len(s) {
+				if v, err := strconv.ParseUint(s[i+2:i+6], 16, 16); err == nil {
+					b.WriteRune(rune(v))
+					i += 6
+					continue
+				}
+			}
+			b.WriteByte(c)
+			i++
+		default:
+			b.WriteByte(next)
+			i += 2
+		}
+	}
+	return b.String()
+}

--- a/sectool/service/js/parse_test.go
+++ b/sectool/service/js/parse_test.go
@@ -1,0 +1,136 @@
+package js
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSource(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid_returns_ast_no_err", func(t *testing.T) {
+		pr := parseSource([]byte(`var x = 1;`))
+		require.NoError(t, pr.err)
+		assert.NotNil(t, pr.ast)
+	})
+
+	t.Run("invalid_returns_err", func(t *testing.T) {
+		pr := parseSource([]byte(`function (`))
+		assert.Error(t, pr.err)
+	})
+
+	t.Run("empty_input", func(t *testing.T) {
+		pr := parseSource(nil)
+		require.NoError(t, pr.err)
+		assert.NotNil(t, pr.ast)
+	})
+}
+
+func TestScanStringLiterals(t *testing.T) {
+	t.Parallel()
+
+	t.Run("double_and_single_quotes", func(t *testing.T) {
+		got := scanStringLiterals([]byte(`var a = "hello"; var b = 'world';`))
+		assert.Contains(t, got, "hello")
+		assert.Contains(t, got, "world")
+	})
+
+	t.Run("decodes_escapes", func(t *testing.T) {
+		got := scanStringLiterals([]byte(`var u = "\/api\/users";`))
+		assert.Contains(t, got, "/api/users")
+	})
+
+	t.Run("plain_template", func(t *testing.T) {
+		got := scanStringLiterals([]byte("var s = `plain`;"))
+		assert.Contains(t, got, "plain")
+	})
+
+	t.Run("interpolated_template_parts_skipped", func(t *testing.T) {
+		// Only StringToken / TemplateToken (whole-template) are captured; the
+		// Start/Middle/End fragments of an interpolated template are emitted as
+		// different token types and intentionally ignored — the AST visitor
+		// reconstructs them with ${...} placeholders.
+		got := scanStringLiterals([]byte("var s = `pre${x}post`;"))
+		assert.NotContains(t, got, "pre")
+		assert.NotContains(t, got, "post")
+	})
+
+	t.Run("ignores_numeric_and_identifiers", func(t *testing.T) {
+		got := scanStringLiterals([]byte(`var n = 123; var foo = bar;`))
+		assert.Empty(t, got)
+	})
+
+	t.Run("stops_at_lex_error", func(t *testing.T) {
+		// A bare quote leaves the lexer in an error state; the function should
+		// return whatever was scanned successfully before that point.
+		got := scanStringLiterals([]byte(`var a = "ok"; var b = "unterminated`))
+		assert.Contains(t, got, "ok")
+	})
+
+	t.Run("empty_input", func(t *testing.T) {
+		assert.Empty(t, scanStringLiterals(nil))
+	})
+}
+
+func TestUnquote(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"double_quoted", `"hello"`, "hello", true},
+		{"single_quoted", `'hello'`, "hello", true},
+		{"backtick_plain", "`hello`", "hello", true},
+		{"escaped_path", `"\/api\/users"`, "/api/users", true},
+		{"unicode_path", `"/api"`, "/api", true},
+		{"too_short", `"`, "", false},
+		{"mismatched", `"hello'`, "", false},
+		{"template_start", "`prefix${", "prefix", true},
+		{"template_middle", "}mid${", "mid", true},
+		{"template_end", "}suffix`", "suffix", true},
+		{"empty_double_quoted", `""`, "", false},
+		{"unrecognized_delim", `xhellox`, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := unquote([]byte(tc.in))
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantOK {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestDecodeJSEscapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no_escapes_fast_path", "/api/users", "/api/users"},
+		{"slash_escape", `\/api\/users`, "/api/users"},
+		{"quote_escape", `it\'s \"x\"`, `it's "x"`},
+		{"newline_tab", `a\nb\tc`, "a\nb\tc"},
+		{"hex_escape", `\x2fapi`, "/api"},
+		{"unicode_escape", "\\u002fapi", "/api"},
+		{"unicode_brace_escape", `\u{1F600}`, "\U0001F600"},
+		{"unknown_escape_dropped", `\zfoo`, "zfoo"},
+		{"trailing_backslash", `foo\`, `foo\`},
+		{"backslash_self", `a\\b`, `a\b`},
+		{"malformed_hex_kept", `\xZZ`, `\xZZ`},
+		{"malformed_unicode_kept", `\uZZZZ`, `\uZZZZ`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, decodeJSEscapes(tc.in))
+		})
+	}
+}

--- a/sectool/service/js/scope.go
+++ b/sectool/service/js/scope.go
@@ -1,0 +1,170 @@
+package js
+
+import (
+	"strings"
+
+	"github.com/tdewolff/parse/v2/js"
+)
+
+// scope holds identifier bindings collected in a pre-pass over the AST.
+// sinkVisitor consults it to gate XHR and router-receiver heuristics.
+// Cross-file and destructured bindings are not tracked.
+type scope struct {
+	xhrReceivers    map[string]struct{}
+	routerReceivers map[string]string // identifier to framework label
+}
+
+// routerProducerCalls lists hook and factory names that return a router instance
+// when imported from a recognized router library.
+var routerProducerCalls = map[string]struct{}{
+	"useNavigate":         {},
+	"useHistory":          {},
+	"useRouter":           {},
+	"useRouterHistory":    {},
+	"createRouter":        {},
+	"createBrowserRouter": {},
+	"createHashRouter":    {},
+	"createMemoryRouter":  {},
+}
+
+// routerConstructors lists classes that produce a router instance via `new`
+// when imported from a recognized router library.
+var routerConstructors = map[string]struct{}{
+	"VueRouter": {},
+}
+
+// buildScope returns the populated scope for ast. Returns an empty scope when ast is nil.
+func buildScope(ast *js.AST) *scope {
+	s := &scope{
+		xhrReceivers:    make(map[string]struct{}),
+		routerReceivers: make(map[string]string),
+	}
+	if ast == nil {
+		return s
+	}
+	v := &scopeVisitor{s: s, routerImports: make(map[string]string)}
+	js.Walk(v, ast)
+	return s
+}
+
+// scopeVisitor walks the AST collecting imports and bindings into scope.
+type scopeVisitor struct {
+	s *scope
+	// routerImports maps locally-bound identifiers from router-library imports to their framework label.
+	routerImports map[string]string
+}
+
+func (v *scopeVisitor) Exit(_ js.INode) {}
+
+func (v *scopeVisitor) Enter(n js.INode) js.IVisitor {
+	switch node := n.(type) {
+	case *js.ImportStmt:
+		v.visitImport(node)
+	case *js.VarDecl:
+		v.visitVarDecl(node)
+	case *js.BinaryExpr:
+		v.visitAssign(node)
+	}
+	return v
+}
+
+// frameworkForModule returns the framework label for an import module, or "" if unrecognized.
+// rawModule is the quoted module string as emitted by the lexer.
+func frameworkForModule(rawModule string) string {
+	m, ok := unquote([]byte(rawModule))
+	if !ok {
+		m = rawModule
+	}
+	switch {
+	case strings.HasPrefix(m, "react-router"):
+		return frameworkReactRouter
+	case strings.HasPrefix(m, "vue-router"):
+		return frameworkVueRouter
+	case m == "@angular/router" || strings.HasPrefix(m, "@angular/router/"):
+		return frameworkAngularRouter
+	}
+	return ""
+}
+
+func (v *scopeVisitor) visitImport(imp *js.ImportStmt) {
+	fw := frameworkForModule(string(imp.Module))
+	if fw == "" {
+		return
+	}
+	if len(imp.Default) > 0 {
+		v.routerImports[string(imp.Default)] = fw
+	}
+	for _, a := range imp.List {
+		name := a.Binding
+		if len(name) == 0 {
+			name = a.Name
+		}
+		if len(name) == 0 {
+			continue
+		}
+		v.routerImports[string(name)] = fw
+	}
+}
+
+func (v *scopeVisitor) visitVarDecl(d *js.VarDecl) {
+	for _, el := range d.List {
+		name, ok := bindingVarName(el.Binding)
+		if !ok || el.Default == nil {
+			continue
+		}
+		v.classifyBinding(name, el.Default)
+	}
+}
+
+// visitAssign handles plain reassignment of XHR or router receivers.
+// var/let/const bindings flow through visitVarDecl instead.
+func (v *scopeVisitor) visitAssign(b *js.BinaryExpr) {
+	if b.Op != js.EqToken {
+		return
+	}
+	name, ok := dotObjectName(b.X)
+	if !ok {
+		return
+	}
+	v.classifyBinding(name, b.Y)
+}
+
+// classifyBinding records name in scope when expr matches a known XHR or router shape.
+func (v *scopeVisitor) classifyBinding(name string, expr js.IExpr) {
+	switch e := expr.(type) {
+	case *js.NewExpr:
+		cname, ok := constructorName(e.X)
+		if !ok {
+			return
+		}
+		if cname == "XMLHttpRequest" {
+			v.s.xhrReceivers[name] = struct{}{}
+			return
+		}
+		if _, isCtor := routerConstructors[cname]; isCtor {
+			if fw, imported := v.routerImports[cname]; imported {
+				v.s.routerReceivers[name] = fw
+			}
+		}
+	case *js.CallExpr:
+		cname, ok := dotObjectName(e.X)
+		if !ok {
+			return
+		}
+		if _, prod := routerProducerCalls[cname]; !prod {
+			return
+		}
+		if fw, imported := v.routerImports[cname]; imported {
+			v.s.routerReceivers[name] = fw
+		}
+	}
+}
+
+// bindingVarName returns the identifier name for a simple Var binding.
+// Destructuring patterns are intentionally unsupported.
+func bindingVarName(b js.IBinding) (string, bool) {
+	if v, ok := b.(*js.Var); ok {
+		return string(v.Data), true
+	}
+	return "", false
+}

--- a/sectool/service/js/scope_test.go
+++ b/sectool/service/js/scope_test.go
@@ -1,0 +1,98 @@
+package js
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tdewolff/parse/v2"
+	"github.com/tdewolff/parse/v2/js"
+)
+
+func TestFrameworkForModule(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		// rawModule is the raw token form the lexer would emit (quoted).
+		rawModule string
+		want      string
+	}{
+		{"react_router_quoted", `"react-router"`, frameworkReactRouter},
+		{"react_router_dom_quoted", `"react-router-dom"`, frameworkReactRouter},
+		{"react_router_native_quoted", `'react-router-native'`, frameworkReactRouter},
+		{"vue_router_quoted", `"vue-router"`, frameworkVueRouter},
+		{"vue_router_subpath", `"vue-router/auto"`, frameworkVueRouter},
+		{"angular_router_quoted", `"@angular/router"`, frameworkAngularRouter},
+		{"angular_router_subpath", `"@angular/router/testing"`, frameworkAngularRouter},
+		{"unrelated_module", `"lodash"`, ""},
+		{"empty_module", `""`, ""},
+		// Real-world: imports come in quoted; the function also tolerates a bare unquoted form.
+		{"bare_unquoted_react_router", `react-router`, frameworkReactRouter},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, frameworkForModule(tc.rawModule))
+		})
+	}
+}
+
+func TestBuildScope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("xhr_var_binding", func(t *testing.T) {
+		s := scopeFor(t, `var xhr = new XMLHttpRequest();`)
+		_, ok := s.xhrReceivers["xhr"]
+		assert.True(t, ok)
+	})
+
+	t.Run("xhr_assign_binding", func(t *testing.T) {
+		s := scopeFor(t, `let xhr; xhr = new XMLHttpRequest();`)
+		_, ok := s.xhrReceivers["xhr"]
+		assert.True(t, ok)
+	})
+
+	t.Run("xhr_unrelated_constructor_ignored", func(t *testing.T) {
+		s := scopeFor(t, `var x = new Foo();`)
+		_, ok := s.xhrReceivers["x"]
+		assert.False(t, ok)
+	})
+
+	t.Run("router_named_import_use_navigate", func(t *testing.T) {
+		s := scopeFor(t, `
+import { useNavigate } from 'react-router';
+const nav = useNavigate();
+`)
+		assert.Equal(t, frameworkReactRouter, s.routerReceivers["nav"])
+	})
+
+	t.Run("router_default_import_use_router", func(t *testing.T) {
+		s := scopeFor(t, `
+import VueRouter from 'vue-router';
+const r = new VueRouter();
+`)
+		assert.Equal(t, frameworkVueRouter, s.routerReceivers["r"])
+	})
+
+	t.Run("router_producer_without_import_rejected", func(t *testing.T) {
+		// useNavigate is recognized only when imported from a router library.
+		s := scopeFor(t, `const nav = useNavigate();`)
+		_, ok := s.routerReceivers["nav"]
+		assert.False(t, ok)
+	})
+
+	t.Run("nil_ast_returns_empty_scope", func(t *testing.T) {
+		s := buildScope(nil)
+		require.NotNil(t, s)
+		assert.Empty(t, s.xhrReceivers)
+		assert.Empty(t, s.routerReceivers)
+	})
+}
+
+func scopeFor(t *testing.T, src string) *scope {
+	t.Helper()
+	ast, err := js.Parse(parse.NewInputBytes([]byte(src)), js.Options{})
+	require.NoError(t, err)
+	return buildScope(ast)
+}

--- a/sectool/service/js/secrets.go
+++ b/sectool/service/js/secrets.go
@@ -1,0 +1,87 @@
+package js
+
+import (
+	"regexp"
+
+	"github.com/go-appsec/toolbox/sectool/protocol"
+)
+
+// secretPattern pairs a credential kind label with an anchored regex.
+// Patterns are intentionally narrow; generic base64/hex shapes are excluded
+// because they produce too many false positives in minified bundles.
+type secretPattern struct {
+	kind string
+	re   *regexp.Regexp
+}
+
+// literalSecretPatterns are matched against full string-literal values extracted from JS.
+var literalSecretPatterns = []secretPattern{
+	{"aws_access_key", regexp.MustCompile(`^AKIA[0-9A-Z]{16}$`)},
+	{"github_fine_grained", regexp.MustCompile(`^github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$`)},
+	{"github_pat", regexp.MustCompile(`^ghp_[a-zA-Z0-9]{36}$`)},
+	{"github_oauth", regexp.MustCompile(`^gho_[a-zA-Z0-9]{36}$`)},
+	{"github_user_token", regexp.MustCompile(`^ghu_[a-zA-Z0-9]{36}$`)},
+	{"github_server_token", regexp.MustCompile(`^ghs_[a-zA-Z0-9]{36}$`)},
+	{"github_refresh", regexp.MustCompile(`^ghr_[a-zA-Z0-9]{36}$`)},
+	{"google_api_key", regexp.MustCompile(`^AIza[0-9A-Za-z\-_]{35}$`)},
+	{"openai_proj_key", regexp.MustCompile(`^sk-proj-[a-zA-Z0-9]{48}$`)},
+	{"openai_api_key", regexp.MustCompile(`^sk-[a-zA-Z0-9]{48}$`)},
+	{"openai_org_key", regexp.MustCompile(`^org-[a-zA-Z0-9]{24}$`)},
+	{"anthropic_api_key", regexp.MustCompile(`^sk-ant-api\d{2}-[a-zA-Z0-9\-_]{80,}$`)},
+	{"vault_service_token", regexp.MustCompile(`^hvs\.[a-zA-Z0-9]{24,}$`)},
+	{"vault_token", regexp.MustCompile(`^s\.[a-zA-Z0-9]{24}$`)},
+	{"vault_batch_token", regexp.MustCompile(`^b\.[a-zA-Z0-9]{24}$`)},
+	{"gitlab_pat", regexp.MustCompile(`^glpat-[a-zA-Z0-9]{20}$`)},
+	{"gitlab_pipeline", regexp.MustCompile(`^glcbt-[a-zA-Z0-9]{20}$`)},
+	{"gitlab_runner", regexp.MustCompile(`^glrt-[a-zA-Z0-9]{20}$`)},
+	{"gitlab_deploy", regexp.MustCompile(`^gldt-[a-zA-Z0-9]{20}$`)},
+	{"stripe_live_key", regexp.MustCompile(`^sk_live_[0-9a-zA-Z]{24,}$`)},
+	{"stripe_test_key", regexp.MustCompile(`^sk_test_[0-9a-zA-Z]{24,}$`)},
+	{"stripe_restricted_key", regexp.MustCompile(`^rk_(live|test)_[0-9a-zA-Z]{24,}$`)},
+	{"stripe_publishable_key", regexp.MustCompile(`^pk_(live|test)_[0-9a-zA-Z]{24,}$`)},
+	{"docker_token", regexp.MustCompile(`^dckr_pat_[a-zA-Z0-9_\-]{27,}$`)},
+	{"npm_token", regexp.MustCompile(`^npm_[a-zA-Z0-9]{36}$`)},
+	{"pypi_token", regexp.MustCompile(`^pypi-[a-zA-Z0-9_\-]{100,}$`)},
+	{"slack_token", regexp.MustCompile(`^xox[baprs]-[0-9a-zA-Z\-]+$`)},
+	{"slack_webhook", regexp.MustCompile(`^https://hooks\.slack\.com/services/[A-Z0-9]+/[A-Z0-9]+/[a-zA-Z0-9]+$`)},
+	{"discord_webhook", regexp.MustCompile(`^https://discord\.com/api/webhooks/[0-9]+/[a-zA-Z0-9_\-]+$`)},
+	{"twilio_api_key", regexp.MustCompile(`^SK[a-z0-9]{32}$`)},
+	{"twilio_account_sid", regexp.MustCompile(`^AC[a-z0-9]{32}$`)},
+	{"sendgrid_api_key", regexp.MustCompile(`^SG\.[a-zA-Z0-9_\-]{22}\.[a-zA-Z0-9_\-]{43}$`)},
+	{"api_key", regexp.MustCompile(`^key-[a-z0-9]{32}$`)}, // e.g., Mailgun
+	{"digitalocean_token", regexp.MustCompile(`^dop_v1_[a-f0-9]{64}$`)},
+	{"shopify_access_token", regexp.MustCompile(`^shpat_[a-f0-9]{32}$`)},
+	{"shopify_custom_token", regexp.MustCompile(`^shpca_[a-f0-9]{32}$`)},
+	{"shopify_private_token", regexp.MustCompile(`^shppa_[a-f0-9]{32}$`)},
+	{"shopify_shared_secret", regexp.MustCompile(`^shpss_[a-f0-9]{32}$`)},
+	{"square_secret", regexp.MustCompile(`^sq0csp-[0-9a-zA-Z_\-]{43}$`)},
+	{"square_access", regexp.MustCompile(`^sq0atp-[0-9a-zA-Z_\-]{22}$`)},
+	{"sentry_dsn", regexp.MustCompile(`^https://[a-f0-9]{32}@[a-z0-9.\-]+/[0-9]+$`)},
+}
+
+// pemPrivateKeyRe matches a PEM private-key armor header.
+// Scanned against the raw body since PEM blocks may span template literals or byte arrays.
+var pemPrivateKeyRe = regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----`)
+
+// extractSecrets returns credential matches from literals and PEM matches from src.
+func extractSecrets(src []byte, literals []string) []protocol.ExtractedSecret {
+	var out []protocol.ExtractedSecret
+	for _, lit := range literals {
+		for _, p := range literalSecretPatterns {
+			if p.re.MatchString(lit) {
+				out = append(out, protocol.ExtractedSecret{
+					Kind:  p.kind,
+					Value: lit,
+				})
+				break
+			}
+		}
+	}
+	if pemPrivateKeyRe.Match(src) {
+		out = append(out, protocol.ExtractedSecret{
+			Kind:  "private_key",
+			Value: "-----BEGIN PRIVATE KEY-----",
+		})
+	}
+	return out
+}

--- a/sectool/service/js/secrets_test.go
+++ b/sectool/service/js/secrets_test.go
@@ -1,0 +1,76 @@
+package js
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractSecrets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matched_literal_kinds", func(t *testing.T) {
+		cases := []struct {
+			name     string
+			literal  string
+			wantKind string
+		}{
+			{"aws_access_key", "AKIAIOSFODNN7EXAMPLE", "aws_access_key"},
+			{"github_pat", "ghp_abcdefghijklmnopqrstuvwxyz0123456789", "github_pat"},
+			{"github_oauth", "gho_abcdefghijklmnopqrstuvwxyz0123456789", "github_oauth"},
+			{"github_fine_grained", "github_pat_11ABCDEFG0abcdefghijkl_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVW", "github_fine_grained"},
+			{"google_api_key", "AIzaSyA-1234567890abcdefghijklmnopqrstu", "google_api_key"},
+			{"openai_api_key", "sk-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV", "openai_api_key"},
+			{"openai_proj_key", "sk-proj-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV", "openai_proj_key"},
+			{"anthropic_api_key", "sk-ant-api03-" + strings.Repeat("a", 95), "anthropic_api_key"},
+			{"stripe_live_key", "sk_live_" + strings.Repeat("a", 30), "stripe_live_key"},
+			{"stripe_publishable_key", "pk_live_" + strings.Repeat("a", 30), "stripe_publishable_key"},
+			{"sentry_dsn", "https://abcdef0123456789abcdef0123456789@sentry.example.com/1234", "sentry_dsn"},
+			{"digitalocean_token", "dop_v1_" + strings.Repeat("a", 64), "digitalocean_token"},
+			{"shopify_access_token", "shpat_" + strings.Repeat("a", 32), "shopify_access_token"},
+			{"sendgrid_api_key", "SG." + strings.Repeat("a", 22) + "." + strings.Repeat("b", 43), "sendgrid_api_key"},
+			{"vault_service_token", "hvs." + strings.Repeat("a", 30), "vault_service_token"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got := extractSecrets(nil, []string{tc.literal})
+				assert.Len(t, got, 1)
+				assert.Equal(t, tc.wantKind, got[0].Kind)
+				assert.Equal(t, tc.literal, got[0].Value)
+			})
+		}
+	})
+
+	t.Run("non_secret_rejected", func(t *testing.T) {
+		negatives := []string{
+			"AKIA_TOO_SHORT",
+			"AKIA123",
+			"sk-tooShort",
+			"ghp_short",
+			"https://example.com/regular/path",
+			"hello world",
+			"Bearer abc",
+			strings.Repeat("A", 40),
+		}
+		got := extractSecrets(nil, negatives)
+		assert.Empty(t, got)
+	})
+
+	t.Run("pem_in_body", func(t *testing.T) {
+		body := []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
+KUpRKfFLfRYC9AIKjbJTWit+CqvjWYzvQwECAwEAAQJAIJLixBy2qpFoS4DSmoEm
+-----END RSA PRIVATE KEY-----`)
+		got := extractSecrets(body, nil)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "private_key", got[0].Kind)
+	})
+
+	t.Run("no_dedupe_within_pass", func(t *testing.T) {
+		// One record per matched literal; collapsing duplicates is dedupeSecrets's job.
+		lit := "AKIAIOSFODNN7EXAMPLE"
+		got := extractSecrets(nil, []string{lit, lit})
+		assert.Len(t, got, 2)
+	})
+}

--- a/sectool/service/mcp_jsanalyze.go
+++ b/sectool/service/mcp_jsanalyze.go
@@ -1,0 +1,218 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"mime"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/go-appsec/toolbox/sectool/protocol"
+	"github.com/go-appsec/toolbox/sectool/service/js"
+)
+
+// jsPrefixes lists leading byte sequences that mark an unlabeled body as JavaScript.
+var jsPrefixes = [][]byte{
+	[]byte("function"),
+	[]byte("var "),
+	[]byte("let "),
+	[]byte("const "),
+	[]byte("import "),
+	[]byte("export "),
+	[]byte("class "),
+	[]byte("(function"),
+	[]byte("!function"),
+	[]byte("/*"),
+	[]byte("//"),
+}
+
+func (m *mcpServer) addJSAnalyzeTools() {
+	m.server.AddTool(m.jsAnalyzeTool(), m.handleJSAnalyze)
+}
+
+func (m *mcpServer) jsAnalyzeTool() mcp.Tool {
+	return mcp.NewTool("js_analyze",
+		mcp.WithDescription(`Extract the API surface from a JavaScript or HTML response flow.
+
+Returns a deduplicated map of:
+- endpoints: every URL referenced by the JS. "literal" entries are URL-shaped string literals found outside any known sink; everything else is a concrete call site or constructor argument.
+- routes: client-side framework routes.
+- secrets: high-precision credential matches.
+- external_scripts: <script src=...> URLs from HTML responses.
+- source_maps: sourceMappingURL hints from the body.
+
+For HTML responses, inline <script> blocks are parsed independently. Each endpoint includes a "last_flow" field (when present) pointing to the most recent matching proxy flow_id.`),
+		mcp.WithString("flow_id", mcp.Required(), mcp.Description("Flow ID (from proxy_poll, replay_send, or crawl_poll)")),
+	)
+}
+
+func (m *mcpServer) handleJSAnalyze(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	if err := m.requireWorkflow(); err != nil {
+		return err, nil
+	}
+
+	flowID := req.GetString("flow_id", "")
+	if flowID == "" {
+		return errorResult("flow_id is required"), nil
+	}
+
+	flow, errResult := m.resolveFlow(ctx, flowID)
+	if errResult != nil {
+		return errResult, nil
+	}
+
+	respHeaders, respBody := splitHeadersBody(flow.RawResponse)
+	headerStr := string(respHeaders)
+	body, _ := decompressForDisplay(respBody, headerStr)
+
+	contentType := extractHeader(headerStr, "Content-Type")
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+	mediaType = strings.ToLower(mediaType)
+
+	var result js.Result
+	switch {
+	case isHTMLMediaType(mediaType):
+		result = js.AnalyzeHTML(body)
+	case isJSMediaType(mediaType), mediaType == "" && looksLikeJS(body):
+		result = js.AnalyzeJS(body)
+	default:
+		return errorResult("flow response is not JavaScript or HTML (Content-Type: " + contentType + ")"), nil
+	}
+
+	_, bundleHost, _ := extractRequestMeta(string(flow.DisplayRequest()))
+	annotateLastFlow(ctx, m, &result, bundleHost)
+
+	resp := &protocol.JSAnalyzeResponse{
+		Source: result.Source,
+		Stats: protocol.JSAnalyzeStats{
+			InputBytes:   len(body),
+			ScriptBlocks: result.ScriptBlocks,
+			ParseErrors:  result.ParseErrors,
+		},
+		Endpoints:       result.Endpoints,
+		Routes:          result.Routes,
+		Secrets:         result.Secrets,
+		ExternalScripts: result.ExternalScripts,
+		SourceMaps:      result.SourceMaps,
+		Warnings:        result.Warnings,
+	}
+
+	log.Printf("js_analyze: flow=%s source=%s endpoints=%d routes=%d secrets=%d parse_errors=%d",
+		flowID, resp.Source,
+		len(resp.Endpoints), len(resp.Routes), len(resp.Secrets), resp.Stats.ParseErrors)
+	return jsonResult(resp)
+}
+
+// isHTMLMediaType reports whether the media type denotes an HTML response.
+func isHTMLMediaType(mt string) bool {
+	return mt == "text/html" || mt == "application/xhtml+xml"
+}
+
+// isJSMediaType reports whether the media type denotes a JavaScript response.
+func isJSMediaType(mt string) bool {
+	switch mt {
+	case "application/javascript", "text/javascript", "application/x-javascript",
+		"application/ecmascript", "text/ecmascript":
+		return true
+	}
+	return false
+}
+
+// looksLikeJS sniffs the start of a body for JS-like content. Used when the
+// content-type is absent (some bundlers and CDNs omit it).
+func looksLikeJS(body []byte) bool {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 || trimmed[0] == '<' {
+		return false
+	}
+	for _, prefix := range jsPrefixes {
+		if bytes.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// annotateLastFlow sets LastFlow on each endpoint to the most recent matching proxy flow_id.
+// bundleHost is the implicit origin for path-relative URLs.
+// History retrieval errors are non-fatal; endpoints are returned without annotations.
+func annotateLastFlow(ctx context.Context, m *mcpServer, r *js.Result, bundleHost string) {
+	if len(r.Endpoints) == 0 {
+		return
+	}
+	entries, err := drainProxyHistory(ctx, m.service.httpBackend, false)
+	if err != nil || len(entries) == 0 {
+		return
+	}
+	idx := buildLastFlowIndex(entries)
+	for i := range r.Endpoints {
+		if id := idx.lookup(r.Endpoints[i].URL, bundleHost); id != "" {
+			r.Endpoints[i].LastFlow = id
+		}
+	}
+}
+
+// lastFlowIndex maps (host, path) to the most recent flow_id.
+// Path-only layers allow query-less literals to match history with queries.
+// blind* maps are host-blind fallbacks for when neither host is known.
+type lastFlowIndex struct {
+	byHost         map[string]map[string]string
+	byHostPathOnly map[string]map[string]string
+	blindPath      map[string]string
+	blindPathOnly  map[string]string
+}
+
+func buildLastFlowIndex(entries []flowEntry) *lastFlowIndex {
+	idx := &lastFlowIndex{
+		byHost:         make(map[string]map[string]string),
+		byHostPathOnly: make(map[string]map[string]string),
+		blindPath:      make(map[string]string, len(entries)),
+		blindPathOnly:  make(map[string]string, len(entries)),
+	}
+	for _, e := range entries {
+		if e.path == "" {
+			continue
+		}
+		pathOnly := js.StripQuery(e.path)
+		if e.host != "" {
+			if idx.byHost[e.host] == nil {
+				idx.byHost[e.host] = make(map[string]string)
+				idx.byHostPathOnly[e.host] = make(map[string]string)
+			}
+			idx.byHost[e.host][e.path] = e.flowID
+			idx.byHostPathOnly[e.host][pathOnly] = e.flowID
+		}
+		idx.blindPath[e.path] = e.flowID
+		idx.blindPathOnly[pathOnly] = e.flowID
+	}
+	return idx
+}
+
+func (idx *lastFlowIndex) lookup(rawURL, bundleHost string) string {
+	host, path := js.ClassifyURL(rawURL)
+	if path == "" {
+		return ""
+	}
+	if host == "" {
+		host = bundleHost
+	}
+	if host != "" {
+		if id, ok := idx.byHost[host][path]; ok {
+			return id
+		}
+		if id, ok := idx.byHostPathOnly[host][js.StripQuery(path)]; ok {
+			return id
+		}
+		return ""
+	}
+	// bundle host unknown AND URL is path-relative: last-resort host-blind lookup
+	if id, ok := idx.blindPath[path]; ok {
+		return id
+	}
+	if id, ok := idx.blindPathOnly[js.StripQuery(path)]; ok {
+		return id
+	}
+	return ""
+}

--- a/sectool/service/mcp_jsanalyze_test.go
+++ b/sectool/service/mcp_jsanalyze_test.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-appsec/toolbox/sectool/protocol"
+)
+
+func TestHandleJSAnalyze(t *testing.T) {
+	t.Parallel()
+
+	t.Run("javascript_bundle_full", func(t *testing.T) {
+		_, mcpClient, mockHTTP, _, _ := setupMockMCPServer(t, nil)
+
+		// A prior proxy flow that the JS bundle's URL should match against.
+		priorFlowID := mockHTTP.AddProxyEntry(
+			"GET /api/users HTTP/1.1\r\nHost: example.com\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n[]",
+			"",
+		)
+
+		jsBody := `
+fetch('/api/users', {method: 'POST'});
+axios.get('/api/items');
+new WebSocket('wss://example.com/ws');
+window.location.href = '/login';
+var key = 'AKIAIOSFODNN7EXAMPLE';
+//# sourceMappingURL=app.js.map
+`
+		bundleFlowID := mockHTTP.AddProxyEntry(
+			"GET /app.js HTTP/1.1\r\nHost: example.com\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n\r\n"+jsBody,
+			"",
+		)
+
+		resp := CallMCPToolJSONOK[protocol.JSAnalyzeResponse](t, mcpClient, "js_analyze",
+			map[string]interface{}{"flow_id": bundleFlowID})
+
+		assert.Equal(t, "javascript", resp.Source)
+
+		endpointURLs := make(map[string]protocol.ExtractedEndpoint, len(resp.Endpoints))
+		for _, e := range resp.Endpoints {
+			endpointURLs[e.URL] = e
+		}
+		require.Contains(t, endpointURLs, "/api/users")
+		assert.Equal(t, "POST", endpointURLs["/api/users"].Method)
+		assert.Equal(t, "fetch", endpointURLs["/api/users"].Library)
+		assert.Equal(t, priorFlowID, endpointURLs["/api/users"].LastFlow)
+
+		require.Contains(t, endpointURLs, "/api/items")
+		assert.Empty(t, endpointURLs["/api/items"].LastFlow)
+
+		require.Contains(t, endpointURLs, "wss://example.com/ws")
+		assert.Equal(t, "websocket", endpointURLs["wss://example.com/ws"].Library)
+
+		assert.Contains(t, resp.SourceMaps, "app.js.map")
+
+		require.Len(t, resp.Secrets, 1)
+		assert.Equal(t, "aws_access_key", resp.Secrets[0].Kind)
+		assert.Equal(t, "AKIAIOSFODNN7EXAMPLE", resp.Secrets[0].Value)
+	})
+
+	t.Run("html_inline", func(t *testing.T) {
+		_, mcpClient, mockHTTP, _, _ := setupMockMCPServer(t, nil)
+
+		html := `<html><head>
+<script src="/static/bundle.js"></script>
+<script>fetch('/api/inline');</script>
+</head></html>`
+		flowID := mockHTTP.AddProxyEntry(
+			"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n"+html,
+			"",
+		)
+
+		resp := CallMCPToolJSONOK[protocol.JSAnalyzeResponse](t, mcpClient, "js_analyze",
+			map[string]interface{}{"flow_id": flowID})
+
+		assert.Equal(t, "html-inline", resp.Source)
+		assert.Equal(t, []string{"/static/bundle.js"}, resp.ExternalScripts)
+
+		assert.True(t, slices.ContainsFunc(resp.Endpoints, func(e protocol.ExtractedEndpoint) bool {
+			return e.URL == "/api/inline"
+		}))
+	})
+
+	t.Run("last_flow_query_fallback", func(t *testing.T) {
+		cases := []struct {
+			name        string
+			historyPath string
+			jsFetchPath string
+		}{
+			{"js_bare_history_query", "/api/things?id=1", "/api/things"},
+			{"js_query_history_bare", "/api/things", "/api/things?x=1"},
+			{"exact_match_wins", "/api/things?id=1", "/api/things?id=1"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, mcpClient, mockHTTP, _, _ := setupMockMCPServer(t, nil)
+
+				historyFlowID := mockHTTP.AddProxyEntry(
+					"GET "+tc.historyPath+" HTTP/1.1\r\nHost: example.com\r\n\r\n",
+					"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n[]",
+					"",
+				)
+
+				jsBody := "fetch('" + tc.jsFetchPath + "');"
+				bundleFlowID := mockHTTP.AddProxyEntry(
+					"GET /app.js HTTP/1.1\r\nHost: example.com\r\n\r\n",
+					"HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n\r\n"+jsBody,
+					"",
+				)
+
+				resp := CallMCPToolJSONOK[protocol.JSAnalyzeResponse](t, mcpClient, "js_analyze",
+					map[string]interface{}{"flow_id": bundleFlowID})
+
+				idx := slices.IndexFunc(resp.Endpoints, func(e protocol.ExtractedEndpoint) bool {
+					return e.URL == tc.jsFetchPath
+				})
+				require.GreaterOrEqual(t, idx, 0)
+				assert.Equal(t, historyFlowID, resp.Endpoints[idx].LastFlow)
+			})
+		}
+	})
+
+	t.Run("cross_host_not_annotated", func(t *testing.T) {
+		_, mcpClient, mockHTTP, _, _ := setupMockMCPServer(t, nil)
+
+		// /api/things lives on a different host than the bundle.
+		mockHTTP.AddProxyEntry(
+			"GET /api/things HTTP/1.1\r\nHost: other.example.com\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n[]",
+			"",
+		)
+		bundleFlowID := mockHTTP.AddProxyEntry(
+			"GET /app.js HTTP/1.1\r\nHost: app.example.com\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n\r\nfetch('/api/things');",
+			"",
+		)
+
+		resp := CallMCPToolJSONOK[protocol.JSAnalyzeResponse](t, mcpClient, "js_analyze",
+			map[string]interface{}{"flow_id": bundleFlowID})
+
+		idx := slices.IndexFunc(resp.Endpoints, func(e protocol.ExtractedEndpoint) bool {
+			return e.URL == "/api/things"
+		})
+		require.GreaterOrEqual(t, idx, 0)
+		assert.Empty(t, resp.Endpoints[idx].LastFlow)
+	})
+
+	t.Run("same_host_path_relative_matches", func(t *testing.T) {
+		_, mcpClient, mockHTTP, _, _ := setupMockMCPServer(t, nil)
+
+		historyFlowID := mockHTTP.AddProxyEntry(
+			"GET /api/things HTTP/1.1\r\nHost: app.example.com\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n[]",
+			"",
+		)
+		bundleFlowID := mockHTTP.AddProxyEntry(
+			"GET /app.js HTTP/1.1\r\nHost: app.example.com\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n\r\nfetch('/api/things');",
+			"",
+		)
+
+		resp := CallMCPToolJSONOK[protocol.JSAnalyzeResponse](t, mcpClient, "js_analyze",
+			map[string]interface{}{"flow_id": bundleFlowID})
+
+		idx := slices.IndexFunc(resp.Endpoints, func(e protocol.ExtractedEndpoint) bool {
+			return e.URL == "/api/things"
+		})
+		require.GreaterOrEqual(t, idx, 0)
+		assert.Equal(t, historyFlowID, resp.Endpoints[idx].LastFlow)
+	})
+
+	t.Run("absolute_url_matches_own_host", func(t *testing.T) {
+		_, mcpClient, mockHTTP, _, _ := setupMockMCPServer(t, nil)
+
+		apiFlowID := mockHTTP.AddProxyEntry(
+			"GET /v1/users HTTP/1.1\r\nHost: api.example.com\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n[]",
+			"",
+		)
+		bundleFlowID := mockHTTP.AddProxyEntry(
+			"GET /app.js HTTP/1.1\r\nHost: app.example.com\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n\r\nfetch('https://api.example.com/v1/users');",
+			"",
+		)
+
+		resp := CallMCPToolJSONOK[protocol.JSAnalyzeResponse](t, mcpClient, "js_analyze",
+			map[string]interface{}{"flow_id": bundleFlowID})
+
+		idx := slices.IndexFunc(resp.Endpoints, func(e protocol.ExtractedEndpoint) bool {
+			return e.URL == "https://api.example.com/v1/users"
+		})
+		require.GreaterOrEqual(t, idx, 0)
+		assert.Equal(t, apiFlowID, resp.Endpoints[idx].LastFlow)
+	})
+
+	t.Run("rejects_non_js", func(t *testing.T) {
+		_, mcpClient, mockHTTP, _, _ := setupMockMCPServer(t, nil)
+
+		flowID := mockHTTP.AddProxyEntry(
+			"GET /data.json HTTP/1.1\r\nHost: example.com\r\n\r\n",
+			"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"x\":1}",
+			"",
+		)
+
+		result := CallMCPTool(t, mcpClient, "js_analyze",
+			map[string]interface{}{"flow_id": flowID})
+		require.True(t, result.IsError)
+	})
+
+	t.Run("unknown_flow", func(t *testing.T) {
+		_, mcpClient, _, _, _ := setupMockMCPServer(t, nil)
+
+		result := CallMCPTool(t, mcpClient, "js_analyze",
+			map[string]interface{}{"flow_id": "no-such-flow"})
+		require.True(t, result.IsError)
+	})
+}

--- a/sectool/service/mcp_oast.go
+++ b/sectool/service/mcp_oast.go
@@ -1,11 +1,12 @@
 package service
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"log"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -215,8 +216,8 @@ func aggregateOastEvents(events []OastEventInfo) []protocol.OastSummaryEntry {
 	}
 
 	// Sort by count descending
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Count > result[j].Count
+	slices.SortFunc(result, func(a, b protocol.OastSummaryEntry) int {
+		return cmp.Compare(b.Count, a.Count)
 	})
 
 	return result
@@ -379,8 +380,8 @@ func (m *mcpServer) handleOastList(ctx context.Context, req mcp.CallToolRequest)
 	}
 
 	// Sort by creation time descending (most recent first)
-	sort.Slice(sessions, func(i, j int) bool {
-		return sessions[i].CreatedAt.After(sessions[j].CreatedAt)
+	slices.SortFunc(sessions, func(a, b OastSessionInfo) int {
+		return b.CreatedAt.Compare(a.CreatedAt)
 	})
 
 	if limit > 0 && len(sessions) > limit {

--- a/sectool/service/mcp_proxy.go
+++ b/sectool/service/mcp_proxy.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -9,7 +10,6 @@ import (
 	"net/http"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -772,11 +772,8 @@ func (s *Server) fetchAllProxyEntries(ctx context.Context, needsFullText bool) (
 	}
 	all := append(proxyEntries, collectReplayHistory(s.replayHistoryStore, needsFullText)...)
 	// Sort: (timestamp, flow_id) merges proxy and replay chronologically
-	sort.SliceStable(all, func(i, j int) bool {
-		if !all[i].timestamp.Equal(all[j].timestamp) {
-			return all[i].timestamp.Before(all[j].timestamp)
-		}
-		return all[i].flowID < all[j].flowID
+	slices.SortStableFunc(all, func(a, b flowEntry) int {
+		return cmp.Or(a.timestamp.Compare(b.timestamp), cmp.Compare(a.flowID, b.flowID))
 	})
 	return all, nil
 }

--- a/sectool/service/mcp_reflection.go
+++ b/sectool/service/mcp_reflection.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -331,11 +332,8 @@ func findReflections(params []protocol.Reflection, rawResp []byte) []protocol.Re
 		}
 	}
 
-	sort.Slice(reflections, func(i, j int) bool {
-		if reflections[i].Source != reflections[j].Source {
-			return reflections[i].Source < reflections[j].Source
-		}
-		return reflections[i].Name < reflections[j].Name
+	slices.SortFunc(reflections, func(a, b protocol.Reflection) int {
+		return cmp.Or(cmp.Compare(a.Source, b.Source), cmp.Compare(a.Name, b.Name))
 	})
 
 	return reflections

--- a/sectool/service/mcp_server.go
+++ b/sectool/service/mcp_server.go
@@ -183,6 +183,7 @@ func (m *mcpServer) registerTools() {
 		m.addCrawlTools()
 		m.addDiffTools()
 		m.addReflectionTools()
+		m.addJSAnalyzeTools()
 	case protocol.WorkflowModeTestReport:
 		m.addProxyTools()
 		m.addReplayTools()
@@ -193,6 +194,7 @@ func (m *mcpServer) registerTools() {
 		m.addJWTTools()
 		m.addDiffTools()
 		m.addReflectionTools()
+		m.addJSAnalyzeTools()
 		// crawl tools excluded
 	default: // Empty (default) workflowMode: require workflow tool call first, all tools registered
 		m.server.AddTool(m.workflowTool(), m.handleWorkflow)
@@ -206,6 +208,7 @@ func (m *mcpServer) registerTools() {
 		m.addCrawlTools()
 		m.addDiffTools()
 		m.addReflectionTools()
+		m.addJSAnalyzeTools()
 	}
 
 	// Register responder tools only when native proxy backend is used

--- a/sectool/service/proxy/history.go
+++ b/sectool/service/proxy/history.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"cmp"
 	"log"
 	"net/http"
 	"slices"
@@ -87,9 +88,8 @@ func (h *HistoryStore) recover() {
 		h.flowOrder = append(h.flowOrder, orderedFlow{flowID: meta.FlowID, timestamp: ts})
 		h.timestampByFlow[meta.FlowID] = ts
 	}
-	sort.Slice(h.flowOrder, func(i, j int) bool {
-		return lessOrder(h.flowOrder[i].timestamp, h.flowOrder[i].flowID,
-			h.flowOrder[j].timestamp, h.flowOrder[j].flowID)
+	slices.SortFunc(h.flowOrder, func(a, b orderedFlow) int {
+		return cmp.Or(a.timestamp.Compare(b.timestamp), cmp.Compare(a.flowID, b.flowID))
 	})
 }
 

--- a/sectool/service/store/notes.go
+++ b/sectool/service/store/notes.go
@@ -2,7 +2,7 @@ package store
 
 import (
 	"log"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -174,8 +174,8 @@ func (s *NoteStore) List(opts NoteListOptions) []*NoteMeta {
 	}
 
 	// Sort by created_at
-	sort.Slice(notes, func(i, j int) bool {
-		return notes[i].CreatedAt.Before(notes[j].CreatedAt)
+	slices.SortFunc(notes, func(a, b *NoteMeta) int {
+		return a.CreatedAt.Compare(b.CreatedAt)
 	})
 
 	// Apply after_id cursor

--- a/sectool/service/store/replay_history.go
+++ b/sectool/service/store/replay_history.go
@@ -1,8 +1,9 @@
 package store
 
 import (
+	"cmp"
 	"log"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -192,11 +193,8 @@ func (s *ReplayHistoryStore) List() []*ReplayHistoryEntry {
 		}
 	}
 
-	sort.Slice(result, func(i, j int) bool {
-		if !result[i].CreatedAt.Equal(result[j].CreatedAt) {
-			return result[i].CreatedAt.Before(result[j].CreatedAt)
-		}
-		return result[i].FlowID < result[j].FlowID
+	slices.SortFunc(result, func(a, b *ReplayHistoryEntry) int {
+		return cmp.Or(a.CreatedAt.Compare(b.CreatedAt), cmp.Compare(a.FlowID, b.FlowID))
 	})
 	return result
 }
@@ -220,11 +218,8 @@ func (s *ReplayHistoryStore) ListMeta() []ReplayHistoryMeta {
 		result = append(result, meta)
 	}
 
-	sort.Slice(result, func(i, j int) bool {
-		if !result[i].CreatedAt.Equal(result[j].CreatedAt) {
-			return result[i].CreatedAt.Before(result[j].CreatedAt)
-		}
-		return result[i].FlowID < result[j].FlowID
+	slices.SortFunc(result, func(a, b ReplayHistoryMeta) int {
+		return cmp.Or(a.CreatedAt.Compare(b.CreatedAt), cmp.Compare(a.FlowID, b.FlowID))
 	})
 	return result
 }

--- a/sectool/service/store/spill.go
+++ b/sectool/service/store/spill.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"cmp"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -11,7 +12,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"sort"
 	"sync"
 
 	"github.com/go-analyze/bulk"
@@ -411,8 +411,9 @@ func (s *spillStore) runEviction() {
 				entries = append(entries, evictionKey{k, e.size, e.accessSeq})
 			}
 		}
-		sort.Slice(entries, func(i, j int) bool { // oldest first (lower seq = older)
-			return entries[i].accessSeq < entries[j].accessSeq
+		// oldest first (lower seq = older)
+		slices.SortFunc(entries, func(a, b evictionKey) int {
+			return cmp.Compare(a.accessSeq, b.accessSeq)
 		})
 		// Reduce entries to only what is needed to meet target
 		bytesToEvict := s.hotBytes - s.evictTargetBytes


### PR DESCRIPTION
This change parses the JavaScript AST for endpoints, client-side routes, WebSocket URLs, secrets, and external script references with last-flow proxy annotation. Helping agents map web clients with less token overheads.

This PR closes #60 