### PR TITLE
feat: Better streaming response support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,8 @@ Global config at `~/.sectool/config.json` (auto-created with defaults):
     "dial_timeout_secs": 20,
     "read_timeout_secs": 240,
     "write_timeout_secs": 60,
-    "exclude_extensions": "<RE2 alternation, see DefaultExcludeExtensions>"
+    "exclude_extensions": "<RE2 alternation, see DefaultExcludeExtensions>",
+    "full_buffer": false
   },
   "crawler": {
     "disallowed_paths": ["*logout*", "*signout*", "*sign-out*", "*delete*", "*remove*"],
@@ -255,6 +256,11 @@ Domain scoping rules:
 Proxy capture exclusion filters (RE2 patterns, `proxy` section):
 - `exclude_extensions` (`*string`): matches file extension from path (no dot), anchored. nil → default (see `DefaultExcludeExtensions`), `""` → disabled
 - Matching requests are still proxied but never stored in history
+
+Streaming responses (`proxy` section):
+- Response bodies stream to the client per unit (chunk/read/DATA frame) and the flow is stored at response-head time (visible with zero `completed_at`), growing as data arrives — SSE, long-poll, and chunked downloads. `flow_get` reports `in_progress: true` while streaming; poll again for more.
+- `full_buffer` (`bool`, default `false`): when a response has body match/replace rules, buffer the whole body before applying them instead of streaming per-chunk. Streaming applies body rules per chunk (a match spanning a chunk boundary is missed); enable `full_buffer` for whole-body rule correctness. Compressed or Content-Length-framed responses with body rules always buffer regardless of this flag.
+- Scope: response bodies over H1, H2, and the proxy path. Native `replay_send`/`request_send` responses are still read fully before storing.
 
 ### Export Bundle Layout
 

--- a/sectool/config/config.go
+++ b/sectool/config/config.go
@@ -80,6 +80,10 @@ type ProxyConfig struct {
 
 	// RE2 alternation of extensions to exclude from capture
 	ExcludeExtensions *string `json:"exclude_extensions"`
+
+	// Buffer whole response bodies before applying body rules, instead of
+	// streaming per-chunk. Only affects flows with response body rules.
+	FullBuffer bool `json:"full_buffer"`
 }
 
 // SidecarsConfig holds declarative settings for out-of-process protocol

--- a/sectool/integration_test.go
+++ b/sectool/integration_test.go
@@ -76,7 +76,7 @@ func createBackend(t *testing.T, backendType httpBackendType) (service.HttpBacke
 		return backend, config.DefaultBurpProxyAddr
 
 	case backendNative:
-		backend, err := service.NewNativeProxyBackend(0, t.TempDir(), 0, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := service.NewNativeProxyBackend(0, t.TempDir(), 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 		go func() { _ = backend.Serve() }()
@@ -757,7 +757,7 @@ func TestIntegration_ReplayQueryModsVerified(t *testing.T) {
 
 	// Setup native backend
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 	// Start proxy server in background
@@ -1027,7 +1027,7 @@ func TestIntegration_HTTPSProxy(t *testing.T) {
 
 	// Setup native backend
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1751,7 +1751,7 @@ func TestIntegration_HTTP2Proxy(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1896,7 +1896,7 @@ func TestIntegration_HTTP2Rules(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -2083,7 +2083,7 @@ func TestIntegration_WebSocketProxy(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -2224,7 +2224,7 @@ func TestIntegration_ForceFlag(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -2335,7 +2335,7 @@ func TestIntegration_MalformedRequests(t *testing.T) {
 	t.Cleanup(normalServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -2563,7 +2563,7 @@ func TestIntegration_ContentLengthMismatch(t *testing.T) {
 	t.Cleanup(normalServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -2788,7 +2788,7 @@ func TestIntegration_ConnectionErrors(t *testing.T) {
 	t.Parallel()
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -2841,7 +2841,7 @@ func TestIntegration_TimeoutHandling(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -3110,7 +3110,7 @@ func TestIntegration_WebSocketRules(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -3519,7 +3519,7 @@ func TestIntegration_SecureWebSocket(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -3634,7 +3634,7 @@ func TestIntegration_HTTP2Replay(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -3796,7 +3796,7 @@ func TestIntegration_WebSocketBinaryFrames(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -3917,7 +3917,7 @@ func TestIntegration_WebSocketPingPong(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	configDir := t.TempDir()
-	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -4051,7 +4051,7 @@ func TestIntegration_CompressedRequestBodyRule(t *testing.T) {
 	// Only test with native backend (Burp may handle compression differently)
 	t.Run("native", func(t *testing.T) {
 		configDir := t.TempDir()
-		backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := service.NewNativeProxyBackend(0, configDir, 0, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 

--- a/sectool/service/backend.go
+++ b/sectool/service/backend.go
@@ -152,6 +152,8 @@ type ProxyEntry struct {
 	Annotations       map[string]any `json:"annotations,omitempty"`
 	InvokedBy         string         `json:"invoked_by,omitempty"`
 	SidecarInstanceID string         `json:"sidecar_instance_id,omitempty"`
+	// InProgress marks a streaming flow whose response has not completed; its body grows across polls.
+	InProgress bool `json:"in_progress,omitempty"`
 	// Placeholder marks an unparseable Burp entry that preserves offset contiguity; skipped for display.
 	Placeholder bool `json:"-"`
 }

--- a/sectool/service/backend_http_native.go
+++ b/sectool/service/backend_http_native.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/go-analyze/bulk"
 	"github.com/go-appsec/toolbox/sectool/protocol"
 	"github.com/go-appsec/toolbox/sectool/service/ids"
 	"github.com/go-appsec/toolbox/sectool/service/proxy"
@@ -79,7 +80,7 @@ var _ SidecarRegistry = (*sidecar.Manager)(nil)
 // NewNativeProxyBackend creates a new native proxy backend.
 // Does NOT start serving - call Serve() separately (typically in a goroutine).
 // Call EnableSidecars before Serve to host the out-of-process sidecar listener.
-func NewNativeProxyBackend(port int, configDir string, maxBodyBytes int, storage store.Provider, timeouts proxy.TimeoutConfig) (*NativeProxyBackend, error) {
+func NewNativeProxyBackend(port int, configDir string, maxBodyBytes int, storage store.Provider, timeouts proxy.TimeoutConfig, fullBuffer bool) (*NativeProxyBackend, error) {
 	historyStorage, err := storage("hist")
 	if err != nil {
 		return nil, fmt.Errorf("history storage: %w", err)
@@ -96,7 +97,7 @@ func NewNativeProxyBackend(port int, configDir string, maxBodyBytes int, storage
 		return nil, fmt.Errorf("responder storage: %w", err)
 	}
 
-	server, err := proxy.NewProxyServer(port, configDir, maxBodyBytes, historyStorage, timeouts)
+	server, err := proxy.NewProxyServer(port, configDir, maxBodyBytes, historyStorage, timeouts, fullBuffer)
 	if err != nil {
 		_ = historyStorage.Close()
 		_ = ruleStorage.Close()
@@ -314,6 +315,7 @@ func (b *NativeProxyBackend) GetProxyEntry(ctx context.Context, flowID string) (
 		Annotations:       entry.Annotations,
 		InvokedBy:         entry.InvokedBy,
 		SidecarInstanceID: entry.SidecarInstanceID,
+		InProgress:        entry.CompletedAt.IsZero(),
 	}, nil
 }
 
@@ -778,6 +780,41 @@ func (b *NativeProxyBackend) ApplyResponseBodyOnlyRules(body []byte, headers typ
 		return body // return original on recompression failure
 	}
 	return result.body
+}
+
+// ApplyRequestHeaderOnlyRules applies only request header rules to headers.
+// Used when a request head is processed before its body.
+func (b *NativeProxyBackend) ApplyRequestHeaderOnlyRules(headers types.Headers) types.Headers {
+	b.rulesMu.RLock()
+	defer b.rulesMu.RUnlock()
+
+	headerRules := b.coreRulesOfTypeLocked(wire.RuleTypeRequestHeader)
+	if len(headerRules) == 0 {
+		return headers
+	}
+	req := b.applyRequestHeaderRules(&types.RawHTTP1Request{Headers: headers}, headerRules)
+	return req.Headers
+}
+
+// ApplyResponseHeaderOnlyRules applies only response header rules to headers.
+// Used when a response head is forwarded before its body arrives.
+func (b *NativeProxyBackend) ApplyResponseHeaderOnlyRules(headers types.Headers) types.Headers {
+	b.rulesMu.RLock()
+	defer b.rulesMu.RUnlock()
+
+	headerRules := b.coreRulesOfTypeLocked(wire.RuleTypeResponseHeader)
+	if len(headerRules) == 0 {
+		return headers
+	}
+	resp := b.applyResponseHeaderRules(&types.RawHTTP1Response{Headers: headers}, headerRules)
+	return resp.Headers
+}
+
+// coreRulesOfTypeLocked returns core-adapter httpRules of the given type. Caller must hold rulesMu.
+func (b *NativeProxyBackend) coreRulesOfTypeLocked(ruleType string) []nativeStoredRule {
+	return bulk.SliceFilter(func(rule nativeStoredRule) bool {
+		return (rule.Adapter == "" || rule.Adapter == types.AdapterScopeCore) && rule.Type == ruleType
+	}, b.httpRules)
 }
 
 // applyRequestHeaderRules applies header rules to request.

--- a/sectool/service/backend_http_native_respond_test.go
+++ b/sectool/service/backend_http_native_respond_test.go
@@ -16,7 +16,7 @@ import (
 func TestNativeProxyBackend_AddResponder(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -41,7 +41,7 @@ func TestNativeProxyBackend_AddResponder(t *testing.T) {
 func TestNativeProxyBackend_AddResponder_DefaultStatus(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -56,7 +56,7 @@ func TestNativeProxyBackend_AddResponder_DefaultStatus(t *testing.T) {
 func TestNativeProxyBackend_DeleteResponder(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -90,7 +90,7 @@ func TestNativeProxyBackend_DeleteResponder(t *testing.T) {
 func TestNativeProxyBackend_ListResponders(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -120,7 +120,7 @@ func TestNativeProxyBackend_ListResponders(t *testing.T) {
 func TestNativeProxyBackend_InterceptRequest(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -177,7 +177,7 @@ func TestNativeProxyBackend_InterceptRequest(t *testing.T) {
 func TestNativeProxyBackend_InterceptRequest_AllMethods(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -202,7 +202,7 @@ func TestNativeProxyBackend_Responder_Persistence(t *testing.T) {
 	respStorage := store.NewMemStorage()
 	provider := sharedMemProvider("resp", respStorage)
 
-	backend1, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{})
+	backend1, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	_, err = backend1.AddResponder(t.Context(), protocol.ResponderEntry{
@@ -215,7 +215,7 @@ func TestNativeProxyBackend_Responder_Persistence(t *testing.T) {
 	_ = backend1.Close(context.Background())
 
 	// New backend over the same responder storage should load persisted responders.
-	backend2, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{})
+	backend2, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend2.Close(context.Background()) })
 
@@ -234,7 +234,7 @@ func TestNativeProxyBackend_Responder_Persistence(t *testing.T) {
 func TestNativeProxyBackend_Responder_LabelUniqueness(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 

--- a/sectool/service/backend_http_native_sidecar_test.go
+++ b/sectool/service/backend_http_native_sidecar_test.go
@@ -23,7 +23,7 @@ func TestNativeProxyBackendSidecarLifecycle(t *testing.T) {
 	t.Parallel()
 
 	socket := filepath.Join(t.TempDir(), "sidecar.sock")
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	require.NoError(t, backend.EnableSidecars(scsidecar.Config{Socket: socket, NativeProxyPort: 0}, nil, store.NewReplayHistoryStore(store.NewMemStorage())))
 

--- a/sectool/service/backend_http_native_test.go
+++ b/sectool/service/backend_http_native_test.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func (nonClosingStorage) Close() error { return nil }
 func TestNativeProxyBackend_CreateAndServe(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	go func() { _ = backend.Serve() }()
@@ -64,7 +65,7 @@ func TestNativeProxyBackend_GetProxyHistory(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	// Start native proxy backend
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = backend.Serve() }()
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
@@ -118,7 +119,7 @@ func TestNativeProxyBackend_GetProxyHistoryMeta(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	// Start native proxy backend
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = backend.Serve() }()
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
@@ -154,10 +155,36 @@ func TestNativeProxyBackend_GetProxyHistoryMeta(t *testing.T) {
 	assert.Equal(t, "http", metas[0].Scheme)
 }
 
+func TestNativeProxyBackend_GetProxyEntryInProgress(t *testing.T) {
+	t.Parallel()
+
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = backend.Close(context.Background()) })
+
+	flowID := backend.server.History().Store(&types.Flow{
+		Adapter:     types.ProtocolHTTP11,
+		ProtocolTag: types.ProtocolHTTP11,
+		Request:     &types.Message{Method: "GET", Path: "/stream", Headers: types.Headers{{Name: "Host", Value: "example.com"}}},
+		Response:    &types.Message{StatusCode: 200, Headers: types.Headers{{Name: "Content-Type", Value: "text/event-stream"}}},
+		StartedAt:   time.Now(),
+		// CompletedAt zero => in progress
+	})
+
+	entry, err := backend.GetProxyEntry(context.Background(), flowID)
+	require.NoError(t, err)
+	assert.True(t, entry.InProgress)
+
+	require.True(t, backend.server.History().Complete(flowID, &types.Message{StatusCode: 200, Body: []byte("data")}, time.Now(), nil))
+	entry, err = backend.GetProxyEntry(context.Background(), flowID)
+	require.NoError(t, err)
+	assert.False(t, entry.InProgress)
+}
+
 func TestNativeProxyBackend_Rules_CRUD(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -195,7 +222,7 @@ func TestNativeProxyBackend_Rules_Persistence(t *testing.T) {
 	ruleStorage := store.NewMemStorage()
 	provider := sharedMemProvider("rule", ruleStorage)
 
-	backend1, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{})
+	backend1, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	_, err = backend1.AddRule(t.Context(), protocol.RuleEntry{
@@ -219,7 +246,7 @@ func TestNativeProxyBackend_Rules_Persistence(t *testing.T) {
 	require.NoError(t, backend1.Close(context.Background()))
 
 	// New backend over the same rule storage should load persisted rules.
-	backend2, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{})
+	backend2, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend2.Close(context.Background()) })
 
@@ -246,7 +273,7 @@ func TestNativeProxyBackend_Rules_DeletePersists(t *testing.T) {
 	ruleStorage := store.NewMemStorage()
 	provider := sharedMemProvider("rule", ruleStorage)
 
-	backend1, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{})
+	backend1, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	_, err = backend1.AddRule(t.Context(), protocol.RuleEntry{
@@ -265,7 +292,7 @@ func TestNativeProxyBackend_Rules_DeletePersists(t *testing.T) {
 	require.NoError(t, backend1.Close(context.Background()))
 
 	// New backend should only see the surviving rule
-	backend2, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{})
+	backend2, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, provider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend2.Close(context.Background()) })
 
@@ -278,7 +305,7 @@ func TestNativeProxyBackend_Rules_DeletePersists(t *testing.T) {
 func TestNativeProxyBackend_Rules_LabelUniqueness(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -307,7 +334,7 @@ func TestNativeProxyBackend_Rules_LabelUniqueness(t *testing.T) {
 func TestNativeProxyBackend_Rules_InvalidType(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -324,7 +351,7 @@ func TestNativeProxyBackend_Rules_InvalidType(t *testing.T) {
 func TestNativeProxyBackend_Rules_Regex(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -365,7 +392,7 @@ func TestNativeProxyBackend_SendRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create backend (doesn't need to serve for SendRequest)
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -406,7 +433,7 @@ func TestNativeProxyBackend_SendRequest_AppliesRules(t *testing.T) {
 		serverURL, err := url.Parse(testServer.URL)
 		require.NoError(t, err)
 
-		backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -445,7 +472,7 @@ func TestNativeProxyBackend_SendRequest_AppliesRules(t *testing.T) {
 		serverURL, err := url.Parse(testServer.URL)
 		require.NoError(t, err)
 
-		backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -477,7 +504,7 @@ func TestNativeProxyBackend_SendRequest_AppliesRules(t *testing.T) {
 		serverURL, err := url.Parse(testServer.URL)
 		require.NoError(t, err)
 
-		backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -522,7 +549,7 @@ func TestNativeProxyBackend_SendRequest_AppliesRules(t *testing.T) {
 		serverURL, err := url.Parse(testServer.URL)
 		require.NoError(t, err)
 
-		backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -555,7 +582,7 @@ func TestNativeProxyBackend_SendRequest_AppliesRules(t *testing.T) {
 func TestNativeProxyBackend_Close(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = backend.Serve() }()
 	require.NoError(t, backend.WaitReady(t.Context()))
@@ -581,7 +608,7 @@ func TestNativeProxyBackend_HTTPS_Proxy(t *testing.T) {
 	t.Cleanup(testServer.Close)
 
 	// Start native proxy backend
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = backend.Serve() }()
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
@@ -634,7 +661,7 @@ func TestApplyRequestRules(t *testing.T) {
 	configDir := t.TempDir() // shared so CA cert is generated once
 
 	t.Run("header_literal", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -663,7 +690,7 @@ func TestApplyRequestRules(t *testing.T) {
 	})
 
 	t.Run("header_regex", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -692,7 +719,7 @@ func TestApplyRequestRules(t *testing.T) {
 	})
 
 	t.Run("body_literal", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -724,7 +751,7 @@ func TestApplyRequestRules(t *testing.T) {
 	})
 
 	t.Run("no_matching_rules", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -753,7 +780,7 @@ func TestApplyRequestRules(t *testing.T) {
 	})
 
 	t.Run("strips_unsupported_accept_encoding", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -782,7 +809,7 @@ func TestApplyRequestRules(t *testing.T) {
 	})
 
 	t.Run("preserves_accept_encoding", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -810,7 +837,7 @@ func TestApplyRequestRules(t *testing.T) {
 	})
 
 	t.Run("multiple_rules", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -849,7 +876,7 @@ func TestApplyRequestRules(t *testing.T) {
 	})
 
 	t.Run("empty_body", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -879,7 +906,7 @@ func TestApplyRequestRules(t *testing.T) {
 	})
 
 	t.Run("compressed_body", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -925,7 +952,7 @@ func TestApplyResponseRules(t *testing.T) {
 	configDir := t.TempDir() // shared so CA cert is generated once
 
 	t.Run("header_literal", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -954,7 +981,7 @@ func TestApplyResponseRules(t *testing.T) {
 	})
 
 	t.Run("body_literal", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -985,7 +1012,7 @@ func TestApplyResponseRules(t *testing.T) {
 	})
 
 	t.Run("compressed_body", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1023,7 +1050,7 @@ func TestApplyResponseRules(t *testing.T) {
 	})
 
 	t.Run("brotli_body", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1059,7 +1086,7 @@ func TestApplyResponseRules(t *testing.T) {
 	})
 
 	t.Run("invalid_brotli_skips_rules", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1093,7 +1120,7 @@ func TestApplyResponseRules(t *testing.T) {
 	})
 
 	t.Run("multiple_encoding_skips_rules", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1134,7 +1161,7 @@ func TestApplyWSRules(t *testing.T) {
 	configDir := t.TempDir() // shared so CA cert is generated once
 
 	t.Run("to_server", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1160,7 +1187,7 @@ func TestApplyWSRules(t *testing.T) {
 	})
 
 	t.Run("to_client", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1186,7 +1213,7 @@ func TestApplyWSRules(t *testing.T) {
 	})
 
 	t.Run("both_directions", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1211,7 +1238,7 @@ func TestApplyWSRules(t *testing.T) {
 	})
 
 	t.Run("regex", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1418,7 +1445,7 @@ func TestApplyRequestBodyOnlyRules(t *testing.T) {
 	configDir := t.TempDir() // shared so CA cert is generated once
 
 	t.Run("compression", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1451,7 +1478,7 @@ func TestApplyRequestBodyOnlyRules(t *testing.T) {
 	})
 
 	t.Run("invalid_compressed", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1478,7 +1505,7 @@ func TestApplyRequestBodyOnlyRules(t *testing.T) {
 	})
 
 	t.Run("no_encoding", func(t *testing.T) {
-		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+		backend, err := NewNativeProxyBackend(0, configDir, 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 
@@ -1505,7 +1532,7 @@ func TestApplyRequestBodyOnlyRules(t *testing.T) {
 func TestNativeProxyBackend_RuleSnapshot(t *testing.T) {
 	t.Parallel()
 
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = backend.Close(context.Background()) })
 

--- a/sectool/service/integration_test.go
+++ b/sectool/service/integration_test.go
@@ -108,7 +108,7 @@ func TestNativeProxyIntegrationTest(t *testing.T) {
 		upstreamAddr := upstreamListener.Addr().String()
 
 		backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024,
-			store.MemProvider, proxy.TimeoutConfig{})
+			store.MemProvider, proxy.TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = backend.Close(context.Background()) })
 

--- a/sectool/service/mcp_proxy.go
+++ b/sectool/service/mcp_proxy.go
@@ -489,6 +489,12 @@ func (m *mcpServer) handleFlowGet(ctx context.Context, req mcp.CallToolRequest) 
 		"response_size": len(respBody),
 	}
 
+	// Streaming flow still in progress: body grows across polls
+	if resolved.InProgress {
+		result["in_progress"] = true
+		result["hint"] = "response still streaming; poll flow_get again for more data"
+	}
+
 	// Source-specific metadata
 	if resolved.Duration > 0 {
 		result["duration"] = resolved.Duration.Round(time.Millisecond).String()

--- a/sectool/service/mcp_server.go
+++ b/sectool/service/mcp_server.go
@@ -512,6 +512,7 @@ type resolvedFlow struct {
 
 	InvokedBy         string // originating sidecar (proxy, replay); empty otherwise
 	SidecarInstanceID string // emitting sidecar instance (proxy); empty otherwise
+	InProgress        bool   // streaming flow whose response has not completed
 }
 
 // DisplayRequest returns the request as shown when retrieved.
@@ -553,6 +554,7 @@ func (m *mcpServer) resolveFlow(ctx context.Context, flowID string) (*resolvedFl
 			Annotations:       entry.Annotations,
 			InvokedBy:         entry.InvokedBy,
 			SidecarInstanceID: entry.SidecarInstanceID,
+			InProgress:        entry.InProgress,
 		}, nil
 	} else if err != nil && !errors.Is(err, ErrNotFound) {
 		return nil, errorResultFromErr("failed to fetch flow: ", err)

--- a/sectool/service/proxy/handler_connect.go
+++ b/sectool/service/proxy/handler_connect.go
@@ -254,7 +254,7 @@ func (h *connectHandler) handleTLS(ctx context.Context, clientConn net.Conn, cli
 			_ = clientTLS.Close()
 			return
 		}
-		h.routeByProtocol(ctx, clientTLS, upstreamConn, negotiatedProto, target)
+		h.routeByClientProto(ctx, clientTLS, upstreamConn, negotiatedProto, targetAddr, sni, target)
 		return
 	}
 
@@ -265,6 +265,27 @@ func (h *connectHandler) handleTLS(ctx context.Context, clientConn net.Conn, cli
 	}
 
 	// Route based on negotiated protocol
+	h.routeByClientProto(ctx, clientTLS, upstreamConn, negotiatedProto, targetAddr, sni, target)
+}
+
+// routeByClientProto re-dials upstream to match the client's negotiated ALPN when it
+// diverges from the upstream negotiation, then routes the decrypted stream.
+func (h *connectHandler) routeByClientProto(ctx context.Context, clientTLS *tls.Conn, upstreamConn net.Conn, negotiatedProto, targetAddr, sni string, target *types.Target) {
+	clientProto := clientTLS.ConnectionState().NegotiatedProtocol
+	if negotiatedProto == alpnH2 && clientProto != alpnH2 {
+		// upstream/cache said h2 but the client offered no h2 (e.g. no ALPN); re-dial
+		// upstream without forcing h2 so both sides speak HTTP/1.1, bypassing the cache
+		newUp, err := h.dialUpstream(ctx, targetAddr, sni, nil)
+		if err != nil {
+			log.Printf("proxy: upstream re-dial for client proto %q failed: %v", clientProto, err)
+			_ = clientTLS.Close()
+			_ = upstreamConn.Close()
+			return
+		}
+		_ = upstreamConn.Close()
+		upstreamConn = newUp
+		negotiatedProto = clientProto // "" routes to the http1 fallthrough adapter
+	}
 	h.routeByProtocol(ctx, clientTLS, upstreamConn, negotiatedProto, target)
 }
 

--- a/sectool/service/proxy/handler_connect_test.go
+++ b/sectool/service/proxy/handler_connect_test.go
@@ -171,7 +171,7 @@ func TestHandle(t *testing.T) {
 	t.Run("connection_established", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		go func() { _ = proxy.Serve() }()
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -202,7 +202,7 @@ func TestHandle(t *testing.T) {
 		}))
 		t.Cleanup(testServer.Close)
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		go func() { _ = proxy.Serve() }()
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -232,7 +232,11 @@ func TestHandle(t *testing.T) {
 		assert.Equal(t, "success", resp.Header.Get("X-Test-Response"))
 		assert.Equal(t, "Hello from HTTPS server", string(body))
 
-		testutil.WaitForCount(t, func() int { return proxy.History().Count() }, 1)
+		// Streamed response: wait for the body to finish accumulating, not just the head
+		require.Eventually(t, func() bool {
+			flows := proxy.History().Page(1, "")
+			return len(flows) == 1 && flows[0].Response != nil && !flows[0].CompletedAt.IsZero()
+		}, 10*time.Second, time.Millisecond)
 
 		entry := firstEntry(t, proxy.History())
 		assert.Equal(t, "http/1.1", entry.ProtocolTag)
@@ -254,7 +258,7 @@ func TestHandle(t *testing.T) {
 		}))
 		t.Cleanup(testServer.Close)
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		go func() { _ = proxy.Serve() }()
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -292,7 +296,7 @@ func TestHandle(t *testing.T) {
 		}))
 		t.Cleanup(testServer.Close)
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		go func() { _ = proxy.Serve() }()
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -329,6 +333,79 @@ func TestHandle(t *testing.T) {
 		assert.Equal(t, "GET", entry.Request.Method)
 		assert.Equal(t, "https", entry.Scheme)
 	})
+}
+
+func TestHandleClientProtoReconciliation(t *testing.T) {
+	t.Parallel()
+
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("proto=" + r.Proto))
+	}))
+	testServer.TLS = &tls.Config{NextProtos: []string{"h2", "http/1.1"}}
+	testServer.StartTLS()
+	t.Cleanup(testServer.Close)
+
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
+	require.NoError(t, err)
+	go func() { _ = proxy.Serve() }()
+	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AddCert(proxy.CertManager().CACert())
+	target := mustParseURL(t, testServer.URL).Host
+
+	// seed the caps cache to h2 with an ALPN-offering client
+	h2Client := &http.Client{Transport: &http.Transport{
+		Proxy:             http.ProxyURL(mustParseURL(t, "http://"+proxy.Addr())),
+		TLSClientConfig:   &tls.Config{RootCAs: caCertPool, InsecureSkipVerify: true},
+		ForceAttemptHTTP2: true,
+	}}
+	req, err := http.NewRequestWithContext(t.Context(), "GET", testServer.URL+"/seed", nil)
+	require.NoError(t, err)
+	resp, err := h2Client.Do(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, "HTTP/2.0", resp.Proto)
+	require.Contains(t, string(body), "proto=HTTP/2.0")
+
+	// no-ALPN client to the same host must be reconciled to HTTP/1.1, not misrouted to h2
+	var d net.Dialer
+	raw, err := d.DialContext(t.Context(), "tcp", proxy.Addr())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = raw.Close() })
+	require.NoError(t, raw.SetDeadline(time.Now().Add(10*time.Second)))
+
+	_, err = raw.Write([]byte("CONNECT " + target + " HTTP/1.1\r\nHost: " + target + "\r\n\r\n"))
+	require.NoError(t, err)
+	br := bufio.NewReader(raw)
+	statusLine, err := br.ReadString('\n')
+	require.NoError(t, err)
+	require.Contains(t, statusLine, "200 Connection Established")
+	for { // drain remaining CONNECT response headers
+		line, err := br.ReadString('\n')
+		require.NoError(t, err)
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+
+	// nil NextProtos means the client offers no ALPN
+	tlsConn := tls.Client(&readerConn{Conn: raw, r: br}, &tls.Config{RootCAs: caCertPool, InsecureSkipVerify: true})
+	require.NoError(t, tlsConn.HandshakeContext(t.Context()))
+	require.Empty(t, tlsConn.ConnectionState().NegotiatedProtocol)
+
+	_, err = tlsConn.Write([]byte("GET /noalpn HTTP/1.1\r\nHost: " + target + "\r\nConnection: close\r\n\r\n"))
+	require.NoError(t, err)
+	noAlpnResp, err := http.ReadResponse(bufio.NewReader(tlsConn), nil)
+	require.NoError(t, err)
+	noAlpnBody, err := io.ReadAll(noAlpnResp.Body)
+	require.NoError(t, err)
+	_ = noAlpnResp.Body.Close()
+
+	assert.Equal(t, 200, noAlpnResp.StatusCode)
+	assert.Contains(t, string(noAlpnBody), "proto=HTTP/1.1")
 }
 
 func TestUpstreamMirrorSpec(t *testing.T) {

--- a/sectool/service/proxy/handler_http1.go
+++ b/sectool/service/proxy/handler_http1.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/url"
@@ -26,6 +27,7 @@ type http1Handler struct {
 	responseInterceptor ResponseInterceptor // optional, nil means no interception
 	reg                 *protocol.Registry
 	timeouts            TimeoutConfig
+	fullBuffer          bool // buffer whole bodies for rules instead of per-chunk streaming
 }
 
 // Handle processes HTTP/1.1 proxy requests with keep-alive support.
@@ -139,56 +141,7 @@ func (h *http1Handler) handleSinglePlainHTTP(ctx context.Context, clientConn net
 	}
 
 	upstreamReader := bufio.NewReader(upstreamConn)
-	interim, resp, err := readFinalResponse(upstreamReader, req.Method, func(ir *types.RawHTTP1Response) error {
-		return h.forwardInterim(clientConn, ir)
-	})
-	if err != nil {
-		log.Printf("proxy: failed to parse response from %s: %v", upstreamAddr, err)
-		// Skip the synthetic error if interim responses already started the wire stream
-		if len(interim) == 0 {
-			if isTimeoutError(err) {
-				h.sendError(clientConn, 504, "Gateway Timeout: read timeout")
-			} else {
-				h.sendError(clientConn, 502, "Bad Gateway: malformed response")
-			}
-		}
-		h.storeEntry(target, req, nil, interim, startTime)
-		return false
-	}
-
-	if h.ruleApplier != nil {
-		resp = h.ruleApplier.ApplyResponseRules(resp)
-	}
-
-	// Serialize response before storage so truncation doesn't affect the wire copy
-	respBytes := resp.SerializeRaw(&buf)
-
-	// Truncate bodies before storing
-	if h.maxBodyBytes > 0 && len(req.Body) > h.maxBodyBytes {
-		req.SetBody(req.Body[:h.maxBodyBytes])
-	}
-	if h.maxBodyBytes > 0 && resp != nil && len(resp.Body) > h.maxBodyBytes {
-		resp.SetBody(resp.Body[:h.maxBodyBytes])
-	}
-
-	// Store before forwarding so history is visible by the time the client sees the response
-	// Avoids a race with query history after the response arrives but before storeEntry
-	h.storeEntry(target, req, resp, interim, startTime)
-
-	// Forward response to client
-	if h.timeouts.WriteTimeout > 0 {
-		_ = clientConn.SetWriteDeadline(time.Now().Add(h.timeouts.WriteTimeout))
-	}
-	if _, err := clientConn.Write(respBytes); err != nil {
-		log.Printf("proxy: failed to send response to client: %v", err)
-		return false
-	}
-
-	if resp.CloseDelimited {
-		return false // mirror the origin's connection-close framing
-	}
-	connHeader := strings.ToLower(resp.GetHeader("Connection"))
-	return connHeader != connectionClose
+	return h.streamResponse(clientConn, upstreamConn, upstreamReader, req, target, startTime)
 }
 
 // extractTarget determines the upstream server from the request.
@@ -324,6 +277,295 @@ func (h *http1Handler) storeEntry(target *types.Target, req *types.RawHTTP1Reque
 	h.history.Store(flow)
 }
 
+// streamResponse reads the upstream response head, then forwards the body to the
+// client, buffering when body rules need the whole body and streaming per unit
+// otherwise. The flow is persisted at head time and grown as the body arrives.
+// Returns whether the client connection may be kept alive.
+func (h *http1Handler) streamResponse(clientConn, upstreamConn net.Conn, upstreamReader *bufio.Reader, req *types.RawHTTP1Request, target *types.Target, startTime time.Time) bool {
+	interim, resp, bodyExpected, headBareLF, headBareCR, err := readFinalResponseHead(upstreamReader, req.Method, func(ir *types.RawHTTP1Response) error {
+		return h.forwardInterim(clientConn, ir)
+	})
+	if err != nil {
+		log.Printf("proxy: failed to parse response from %s: %v", target.Hostname, err)
+		// Skip the synthetic error if interim responses already started the wire stream
+		if len(interim) == 0 {
+			if isTimeoutError(err) {
+				h.sendError(clientConn, 504, "Gateway Timeout: read timeout")
+			} else {
+				h.sendError(clientConn, 502, "Bad Gateway: malformed response")
+			}
+		}
+		h.storeEntry(target, req, nil, interim, startTime)
+		return false
+	}
+
+	hasBodyRules := h.ruleApplier != nil && h.ruleApplier.HasBodyRules(false)
+	// Buffer when body rules need the whole body: full_buffer, or a framing where
+	// per-unit mutation is unsafe (compressed, or Content-Length pinned on the wire).
+	if !bodyExpected || (hasBodyRules && (h.fullBuffer || mustBufferResponse(resp))) {
+		return h.forwardBuffered(clientConn, upstreamReader, resp, interim, req, target, startTime, bodyExpected, headBareLF, headBareCR)
+	}
+	return h.forwardStreaming(clientConn, upstreamConn, upstreamReader, resp, interim, req, target, startTime, hasBodyRules, headBareLF, headBareCR)
+}
+
+// mustBufferResponse reports whether a response with body rules must be fully
+// buffered because per-unit rule application would be wrong: a compressed body
+// (no fragment is independently decodable) or a Content-Length-framed body
+// (whose length is already committed to the wire).
+func mustBufferResponse(resp *types.RawHTTP1Response) bool {
+	if resp.GetHeader("Content-Encoding") != "" {
+		return true
+	}
+	if strings.Contains(strings.ToLower(resp.GetHeader("Transfer-Encoding")), "chunked") {
+		return false
+	}
+	cl := resp.GetHeader("Content-Length")
+	if cl == "" {
+		return false // close-delimited: length not pinned
+	}
+	n, perr := strconv.ParseInt(cl, 10, 64)
+	return perr == nil && n >= 0
+}
+
+// forwardBuffered reads the whole response body, applies response rules, and
+// forwards and stores it in one shot. Also handles bodyExpected=false (no body).
+func (h *http1Handler) forwardBuffered(clientConn net.Conn, upstreamReader *bufio.Reader, resp *types.RawHTTP1Response, interim []*types.RawHTTP1Response, req *types.RawHTTP1Request, target *types.Target, startTime time.Time, bodyExpected, usedBareLF, usedBareCR bool) bool {
+	var wasChunked bool
+	if bodyExpected {
+		var trailersBareLF, trailersBareCR bool
+		var rerr error
+		if resp.Body, resp.Trailers, wasChunked, resp.Chunks, trailersBareLF, trailersBareCR, rerr = readResponseBodyWithWire(upstreamReader, resp, nil); rerr != nil && !errors.Is(rerr, io.EOF) {
+			log.Printf("proxy: failed to read response body from %s: %v", target.Hostname, rerr)
+			h.storeEntry(target, req, nil, interim, startTime)
+			return false
+		}
+		chunksBareLF, chunksBareCR := chunksBareFlags(resp.Chunks)
+		usedBareLF = usedBareLF || chunksBareLF || trailersBareLF
+		usedBareCR = usedBareCR || chunksBareCR || trailersBareCR
+	}
+	if usedBareLF || usedBareCR || wasChunked {
+		resp.Wire = &types.WireFormat{WasChunked: wasChunked, UsedBareLF: usedBareLF, UsedBareCR: usedBareCR}
+	}
+
+	if h.ruleApplier != nil {
+		resp = h.ruleApplier.ApplyResponseRules(resp)
+	}
+
+	// Serialize before truncation so the stored cap doesn't affect the wire copy
+	var buf bytes.Buffer
+	respBytes := resp.SerializeRaw(&buf)
+
+	h.capBody(req)
+	if h.maxBodyBytes > 0 && len(resp.Body) > h.maxBodyBytes {
+		resp.SetBody(resp.Body[:h.maxBodyBytes])
+	}
+	h.storeEntry(target, req, resp, interim, startTime)
+
+	if h.timeouts.WriteTimeout > 0 {
+		_ = clientConn.SetWriteDeadline(time.Now().Add(h.timeouts.WriteTimeout))
+	}
+	if _, werr := clientConn.Write(respBytes); werr != nil {
+		log.Printf("proxy: failed to send response to client: %v", werr)
+		return false
+	}
+
+	if resp.CloseDelimited {
+		return false // mirror the origin's connection-close framing
+	}
+	return strings.ToLower(resp.GetHeader("Connection")) != connectionClose
+}
+
+// forwardStreaming writes the response head, then streams each body unit to the
+// client while growing the stored flow. Body rules apply per unit (uncompressed
+// chunked/close-delimited only). Returns whether keep-alive may continue.
+func (h *http1Handler) forwardStreaming(clientConn, upstreamConn net.Conn, upstreamReader *bufio.Reader, resp *types.RawHTTP1Response, interim []*types.RawHTTP1Response, req *types.RawHTTP1Request, target *types.Target, startTime time.Time, hasBodyRules, headBareLF, headBareCR bool) bool {
+	if h.ruleApplier != nil {
+		resp.Headers = h.ruleApplier.ApplyResponseHeaderOnlyRules(resp.Headers)
+	}
+
+	isChunked := strings.Contains(strings.ToLower(resp.GetHeader("Transfer-Encoding")), "chunked")
+	if headBareLF || headBareCR || isChunked {
+		resp.Wire = &types.WireFormat{WasChunked: isChunked, UsedBareLF: headBareLF, UsedBareCR: headBareCR}
+	}
+
+	// Store the head first so history is visible before the client sees bytes
+	h.capBody(req)
+	flowID, captured := h.storeStreamHead(target, req, resp, interim, startTime)
+
+	// Forward the head to the client
+	var headBuf bytes.Buffer
+	if h.timeouts.WriteTimeout > 0 {
+		_ = clientConn.SetWriteDeadline(time.Now().Add(h.timeouts.WriteTimeout))
+	}
+	if _, werr := clientConn.Write(resp.SerializeHead(&headBuf)); werr != nil {
+		log.Printf("proxy: failed to send response head to client: %v", werr)
+		if captured {
+			h.completeStreamFlow(flowID, resp, nil, time.Now(), map[string]any{annStreamTruncated: true, annStreamReason: reasonClientDisconnect})
+		}
+		return false
+	}
+
+	var histBody bytes.Buffer
+	var truncated bool
+	throttle := newFlushThrottle()
+	// client write failure; preferred over readErr to classify a disconnect
+	var clientErr error
+
+	onUnit := func(decoded, wire []byte) error {
+		out := decoded
+		if hasBodyRules {
+			out = h.ruleApplier.ApplyResponseBodyOnlyRules(decoded, resp.Headers)
+		}
+
+		var toWrite []byte
+		if isChunked {
+			if hasBodyRules {
+				var cbuf bytes.Buffer
+				types.WriteChunk(&cbuf, out, "\r\n") // re-frame mutated data
+				toWrite = cbuf.Bytes()
+			} else {
+				toWrite = wire // verbatim frame
+			}
+		} else {
+			toWrite = out
+		}
+
+		if h.timeouts.WriteTimeout > 0 {
+			_ = clientConn.SetWriteDeadline(time.Now().Add(h.timeouts.WriteTimeout))
+		}
+		if _, werr := clientConn.Write(toWrite); werr != nil {
+			clientErr = werr
+			return werr
+		}
+
+		// Refresh the upstream idle deadline per unit for long-lived streams
+		if h.timeouts.ReadTimeout > 0 {
+			_ = upstreamConn.SetReadDeadline(time.Now().Add(h.timeouts.ReadTimeout))
+		}
+
+		appendCapped(&histBody, out, h.maxBodyBytes, &truncated)
+		if captured {
+			now := time.Now()
+			if throttle.should(histBody.Len(), now) {
+				h.completeStreamFlow(flowID, resp, histBody.Bytes(), time.Time{}, nil)
+				throttle.mark(histBody.Len(), now)
+			}
+		}
+		return nil
+	}
+
+	_, trailers, _, chunks, _, _, readErr := readResponseBodyWithWire(upstreamReader, resp, onUnit)
+
+	// Forward the chunked terminator (0-chunk + trailers)
+	if isChunked && clientErr == nil {
+		var tbuf bytes.Buffer
+		if !hasBodyRules {
+			if last := lastChunkFrame(chunks); last != nil {
+				tbuf.Write(last.SizeLine)
+				tbuf.WriteString(last.SizeEnding.Bytes())
+				tbuf.Write(trailers)
+				tbuf.WriteString(last.DataEnding.Bytes())
+			} else {
+				types.WriteLastChunk(&tbuf, trailers, "\r\n")
+			}
+		} else {
+			types.WriteLastChunk(&tbuf, trailers, "\r\n")
+		}
+		if h.timeouts.WriteTimeout > 0 {
+			_ = clientConn.SetWriteDeadline(time.Now().Add(h.timeouts.WriteTimeout))
+		}
+		if _, werr := clientConn.Write(tbuf.Bytes()); werr != nil {
+			clientErr = werr
+		}
+	}
+
+	if captured {
+		resp.Trailers = trailers
+		h.completeStreamFlow(flowID, resp, histBody.Bytes(), time.Now(), streamAnnotations(clientErr, readErr, truncated))
+	}
+
+	if clientErr != nil || resp.CloseDelimited {
+		return false
+	}
+	return strings.ToLower(resp.GetHeader("Connection")) != connectionClose
+}
+
+// storeStreamHead persists the request and response head as an in-progress flow
+// (zero CompletedAt), returning its flow_id and whether it was captured.
+func (h *http1Handler) storeStreamHead(target *types.Target, req *types.RawHTTP1Request, resp *types.RawHTTP1Response, interim []*types.RawHTTP1Response, startTime time.Time) (string, bool) {
+	flow := &types.Flow{
+		Adapter:     types.ProtocolHTTP11,
+		ProtocolTag: types.ProtocolHTTP11,
+		Scheme:      target.Scheme(),
+		Port:        target.Port,
+		Request:     types.RequestToMessage(req),
+		Response:    types.ResponseToMessage(resp),
+		StartedAt:   startTime,
+	}
+	for _, ir := range interim {
+		flow.InterimResponses = append(flow.InterimResponses, types.ResponseToMessage(ir))
+	}
+	if !h.history.ShouldCapture(flow) {
+		return "", false
+	}
+	return h.history.Store(flow), true
+}
+
+// completeStreamFlow updates a stored streaming flow with the accumulated body.
+// A non-zero completedAt marks the stream finished; nil body leaves it empty.
+func (h *http1Handler) completeStreamFlow(flowID string, resp *types.RawHTTP1Response, body []byte, completedAt time.Time, annotations map[string]any) {
+	msg := types.ResponseToMessage(resp)
+	msg.Body = body
+	msg.Chunks = nil // per-chunk framing is not retained for streamed bodies
+	h.history.Complete(flowID, msg, completedAt, annotations)
+}
+
+// capBody truncates the stored request body to maxBodyBytes.
+func (h *http1Handler) capBody(req *types.RawHTTP1Request) {
+	if h.maxBodyBytes > 0 && len(req.Body) > h.maxBodyBytes {
+		req.SetBody(req.Body[:h.maxBodyBytes])
+	}
+}
+
+// appendCapped appends data to buf up to maxBytes, setting truncated when the cap
+// is reached. maxBytes <= 0 means no limit.
+func appendCapped(buf *bytes.Buffer, data []byte, maxBytes int, truncated *bool) {
+	if maxBytes <= 0 {
+		buf.Write(data)
+		return
+	}
+	room := maxBytes - buf.Len()
+	if room <= 0 {
+		*truncated = true
+		return
+	}
+	if len(data) > room {
+		buf.Write(data[:room])
+		*truncated = true
+		return
+	}
+	buf.Write(data)
+}
+
+// lastChunkFrame returns the final recorded chunk frame, or nil when none.
+func lastChunkFrame(chunks []types.ChunkFrame) *types.ChunkFrame {
+	if len(chunks) == 0 {
+		return nil
+	}
+	return &chunks[len(chunks)-1]
+}
+
+// streamAnnotations builds finalize-time annotations describing truncation.
+func streamAnnotations(clientErr, readErr error, truncated bool) map[string]any {
+	var reason string
+	if clientErr != nil {
+		reason = reasonClientDisconnect
+	} else if readErr != nil && !errors.Is(readErr, io.EOF) {
+		reason = reasonUpstreamError
+	}
+	return truncationAnnotations(reason, truncated)
+}
+
 // HandleTLS handles HTTP/1.1 traffic over already-established TLS connections.
 // Used by CONNECT handler after TLS handshake is complete.
 // Loops handling request/response pairs until connection closes.
@@ -424,50 +666,5 @@ func (h *http1Handler) handleSingleTLS(ctx context.Context, clientConn, upstream
 		_ = upstreamConn.SetReadDeadline(time.Now().Add(h.timeouts.ReadTimeout))
 	}
 
-	interim, resp, err := readFinalResponse(upstreamReader, req.Method, func(ir *types.RawHTTP1Response) error {
-		return h.forwardInterim(clientConn, ir)
-	})
-	if err != nil {
-		log.Printf("proxy: failed to parse TLS response: %v", err)
-		// Skip the synthetic error if interim responses already started the wire stream
-		if len(interim) == 0 {
-			if isTimeoutError(err) {
-				h.sendError(clientConn, 504, "Gateway Timeout: read timeout")
-			} else {
-				h.sendError(clientConn, 502, "Bad Gateway: malformed response")
-			}
-		}
-		h.storeEntry(target, req, nil, interim, startTime)
-		return false
-	}
-
-	// Apply response rules
-	if h.ruleApplier != nil {
-		resp = h.ruleApplier.ApplyResponseRules(resp)
-	}
-
-	// Forward response to client
-	if h.timeouts.WriteTimeout > 0 {
-		_ = clientConn.SetWriteDeadline(time.Now().Add(h.timeouts.WriteTimeout))
-	}
-	if _, err := clientConn.Write(resp.SerializeRaw(&buf)); err != nil {
-		log.Printf("proxy: failed to send TLS response to client: %v", err)
-		return false
-	}
-
-	// Truncate bodies before storing in history
-	if h.maxBodyBytes > 0 && len(req.Body) > h.maxBodyBytes {
-		req.SetBody(req.Body[:h.maxBodyBytes])
-	}
-	if h.maxBodyBytes > 0 && len(resp.Body) > h.maxBodyBytes {
-		resp.SetBody(resp.Body[:h.maxBodyBytes])
-	}
-
-	h.storeEntry(target, req, resp, interim, startTime)
-
-	if resp.CloseDelimited {
-		return false // mirror the origin's connection-close framing
-	}
-	connHeader := strings.ToLower(resp.GetHeader("Connection"))
-	return connHeader != connectionClose
+	return h.streamResponse(clientConn, upstreamConn, upstreamReader, req, target, startTime)
 }

--- a/sectool/service/proxy/handler_http1_stream_test.go
+++ b/sectool/service/proxy/handler_http1_stream_test.go
@@ -1,0 +1,199 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-appsec/toolbox/sectool/service/proxy/types"
+	"github.com/go-appsec/toolbox/sectool/service/store"
+)
+
+// syncBuf is a concurrency-safe byte sink for reading a streamed response.
+type syncBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// chunkedTrickleUpstream accepts one connection, sends a chunked response head
+// and the first chunk, then waits on gate before sending the second chunk and
+// terminator. Returns the listener address.
+func chunkedTrickleUpstream(t *testing.T, gate <-chan struct{}) string {
+	t.Helper()
+	var lc net.ListenConfig
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		br := bufio.NewReader(conn)
+		for { // drain the request head
+			line, rerr := br.ReadString('\n')
+			if rerr != nil || line == "\r\n" {
+				break
+			}
+		}
+
+		_, _ = io.WriteString(conn, "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+		writeChunk(conn, "data: one\n\n")
+		<-gate
+		writeChunk(conn, "data: two\n\n")
+		_, _ = io.WriteString(conn, "0\r\n\r\n")
+	}()
+
+	return ln.Addr().String()
+}
+
+func writeChunk(w io.Writer, payload string) {
+	_, _ = io.WriteString(w, fmt.Sprintf("%x\r\n%s\r\n", len(payload), payload))
+}
+
+// replaceBodyRuleApplier mutates response bodies (per unit) by replacing find with replace.
+type replaceBodyRuleApplier struct {
+	find, replace []byte
+}
+
+func (replaceBodyRuleApplier) ApplyRequestRules(r *types.RawHTTP1Request) *types.RawHTTP1Request {
+	return r
+}
+func (replaceBodyRuleApplier) ApplyResponseRules(r *types.RawHTTP1Response) *types.RawHTTP1Response {
+	return r
+}
+func (replaceBodyRuleApplier) ApplyRequestBodyOnlyRules(b []byte, _ types.Headers) ([]byte, error) {
+	return b, nil
+}
+func (a replaceBodyRuleApplier) ApplyResponseBodyOnlyRules(b []byte, _ types.Headers) []byte {
+	return bytes.ReplaceAll(b, a.find, a.replace)
+}
+func (replaceBodyRuleApplier) ApplyRequestHeaderOnlyRules(h types.Headers) types.Headers  { return h }
+func (replaceBodyRuleApplier) ApplyResponseHeaderOnlyRules(h types.Headers) types.Headers { return h }
+func (replaceBodyRuleApplier) ApplyWSRules(p []byte, _ string) []byte                     { return p }
+func (replaceBodyRuleApplier) HasBodyRules(isRequest bool) bool                           { return !isRequest }
+
+func TestHTTP1StreamingResponseWithRules(t *testing.T) {
+	t.Parallel()
+
+	gate := make(chan struct{})
+	close(gate) // send both chunks immediately
+	upstreamAddr := chunkedTrickleUpstream(t, gate)
+
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
+	require.NoError(t, err)
+	proxy.SetRuleApplier(replaceBodyRuleApplier{find: []byte("one"), replace: []byte("ONE")})
+	go func() { _ = proxy.Serve() }()
+	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
+	require.NoError(t, proxy.WaitReady(t.Context()))
+
+	var d net.Dialer
+	conn, err := d.DialContext(t.Context(), "tcp", proxy.Addr())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	req := "GET http://" + upstreamAddr + "/events HTTP/1.1\r\nHost: " + upstreamAddr + "\r\n\r\n"
+	_, err = conn.Write([]byte(req))
+	require.NoError(t, err)
+
+	received := &syncBuf{}
+	go func() { _, _ = io.Copy(received, conn) }()
+
+	// Per-unit rule mutates the streamed body on the wire
+	require.Eventually(t, func() bool {
+		return strings.Contains(received.String(), "data: ONE") && strings.Contains(received.String(), "data: two")
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// History stores the mutated body
+	require.Eventually(t, func() bool {
+		flows := proxy.History().Page(1, "")
+		if len(flows) != 1 || flows[0].Response == nil || flows[0].CompletedAt.IsZero() {
+			return false
+		}
+		return strings.Contains(string(flows[0].Response.Body), "ONE")
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestHTTP1StreamingResponse(t *testing.T) {
+	t.Parallel()
+
+	gate := make(chan struct{})
+	upstreamAddr := chunkedTrickleUpstream(t, gate)
+
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
+	require.NoError(t, err)
+	go func() { _ = proxy.Serve() }()
+	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
+	require.NoError(t, proxy.WaitReady(t.Context()))
+
+	var d net.Dialer
+	conn, err := d.DialContext(t.Context(), "tcp", proxy.Addr())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	req := "GET http://" + upstreamAddr + "/events HTTP/1.1\r\nHost: " + upstreamAddr + "\r\n\r\n"
+	_, err = conn.Write([]byte(req))
+	require.NoError(t, err)
+
+	received := &syncBuf{}
+	go func() { _, _ = io.Copy(received, conn) }()
+
+	// First chunk reaches the client before the upstream sends the second
+	require.Eventually(t, func() bool {
+		return strings.Contains(received.String(), "data: one")
+	}, 2*time.Second, 10*time.Millisecond)
+	assert.NotContains(t, received.String(), "data: two")
+
+	// History shows the flow in progress with the partial body
+	var flowID string
+	require.Eventually(t, func() bool {
+		flows := proxy.History().Page(1, "")
+		if len(flows) != 1 || flows[0].Response == nil {
+			return false
+		}
+		flowID = flows[0].FlowID
+		return flows[0].CompletedAt.IsZero() && strings.Contains(string(flows[0].Response.Body), "one")
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Release the second chunk
+	close(gate)
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(received.String(), "data: two")
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// History now shows the completed flow with the full body
+	require.Eventually(t, func() bool {
+		flow, ok := proxy.History().Get(flowID)
+		if !ok || flow.Response == nil {
+			return false
+		}
+		body := string(flow.Response.Body)
+		return !flow.CompletedAt.IsZero() && strings.Contains(body, "one") && strings.Contains(body, "two")
+	}, 2*time.Second, 10*time.Millisecond)
+}

--- a/sectool/service/proxy/handler_http1_test.go
+++ b/sectool/service/proxy/handler_http1_test.go
@@ -16,6 +16,29 @@ import (
 	"github.com/go-appsec/toolbox/sectool/service/store"
 )
 
+func TestMustBufferResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		headers types.Headers
+		want    bool
+	}{
+		{"compressed", types.Headers{{Name: "Content-Encoding", Value: "gzip"}, {Name: "Content-Length", Value: "10"}}, true},
+		{"content_length", types.Headers{{Name: "Content-Length", Value: "10"}}, true},
+		{"chunked", types.Headers{{Name: "Transfer-Encoding", Value: "chunked"}}, false},
+		{"chunked_over_length", types.Headers{{Name: "Transfer-Encoding", Value: "chunked"}, {Name: "Content-Length", Value: "10"}}, false},
+		{"close_delimited", types.Headers{{Name: "Content-Type", Value: "text/event-stream"}}, false},
+		{"invalid_content_length", types.Headers{{Name: "Content-Length", Value: "notanumber"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &types.RawHTTP1Response{StatusCode: 200, Headers: tt.headers}
+			assert.Equal(t, tt.want, mustBufferResponse(resp))
+		})
+	}
+}
+
 func newTestHTTP1Handler(t *testing.T) *http1Handler {
 	t.Helper()
 

--- a/sectool/service/proxy/handler_http2.go
+++ b/sectool/service/proxy/handler_http2.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"slices"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +25,8 @@ const (
 	streamIdleTimeout = 5 * time.Minute
 	cleanupInterval   = 1 * time.Minute
 	h2Preface         = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+	// shutdownFlushGrace bounds the per-write flush of queued frames at teardown
+	shutdownFlushGrace = 2 * time.Second
 )
 
 // h2ConnDesc summarizes a TLS connection for diagnostic logging: remote addr,
@@ -77,6 +78,7 @@ type http2Handler struct {
 	responseInterceptor ResponseInterceptor
 	maxBodyBytes        int
 	timeouts            TimeoutConfig
+	fullBuffer          bool // buffer whole bodies for rules instead of per-frame streaming
 }
 
 // newHTTP2Handler creates a new HTTP/2 handler.
@@ -110,9 +112,10 @@ type h2Stream struct {
 	reqBody    bytes.Buffer // history capture (limited to maxBodyBytes)
 
 	// Response data
-	statusCode  int
-	respHeaders types.Headers
-	respBody    bytes.Buffer // history capture (limited to maxBodyBytes)
+	statusCode            int
+	respHeaders           types.Headers
+	respBody              bytes.Buffer // history capture (limited to maxBodyBytes)
+	respBodyHistTruncated bool         // response history buffer hit maxBodyBytes
 
 	// Full body buffers holding the complete body (up to maxBodyBytes) for rule application
 	reqBodyFull  bytes.Buffer
@@ -122,6 +125,11 @@ type h2Stream struct {
 	// fallback to streaming passthrough (body rules skipped, no truncation)
 	reqBodyOverflow  bool
 	respBodyOverflow bool
+
+	// Two-phase persistence: flow stored at response head, grown as DATA arrives
+	flowID    string
+	captured  bool
+	respFlush flushThrottle
 
 	// Timing
 	startTime    time.Time
@@ -237,12 +245,13 @@ func (h *http2Handler) Handle(ctx context.Context, clientConn, upstreamConn *tls
 	proxyCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Close connections when context is cancelled to unblock blocking reads.
-	// ReadFrame doesn't accept context, so closing is the only way to interrupt it.
+	// unblock context-unaware ReadFrame without tearing down the write side;
+	// sockets are closed after wg.Wait once writers have flushed
 	go func() {
 		<-proxyCtx.Done()
-		_ = clientConn.Close()
-		_ = upstreamConn.Close()
+		now := time.Now()
+		_ = clientConn.SetReadDeadline(now)
+		_ = upstreamConn.SetReadDeadline(now)
 	}()
 
 	proxy := &h2Proxy{
@@ -294,6 +303,15 @@ func (h *http2Handler) Handle(ctx context.Context, clientConn, upstreamConn *tls
 	go proxy.cleanupStaleStreams()
 
 	proxy.wg.Wait()
+
+	// writers have flushed; safe to close the sockets now
+	_ = clientConn.Close()
+	_ = upstreamConn.Close()
+
+	// Finalize any stream still open at connection teardown
+	for _, stream := range proxy.streams.all() {
+		proxy.storeStreamInHistory(stream, reasonConnClosed)
+	}
 }
 
 // exchangeSettings performs the initial SETTINGS exchange.
@@ -490,7 +508,7 @@ func (p *h2Proxy) readFrames(fromClient bool) {
 			return
 
 		case *http2.RSTStreamFrame:
-			p.handleRSTStreamFrame(&buf, f, dst)
+			p.handleRSTStreamFrame(&buf, f, dst, fromClient)
 
 		case *http2.PriorityFrame:
 			p.forwardPriorityFrame(&buf, f, dst)
@@ -641,16 +659,7 @@ func (p *h2Proxy) processHeaders(buf *bytes.Buffer, streamID uint32, block []byt
 
 			// Apply request header rules
 			if p.handler.ruleApplier != nil {
-				// Convert to RawHTTP1Request for rule application
-				pathPart, queryPart, _ := strings.Cut(stream.path, "?")
-				req := &types.RawHTTP1Request{
-					Method:  stream.method,
-					Path:    pathPart,
-					Query:   queryPart,
-					Headers: headers,
-				}
-				req = p.handler.ruleApplier.ApplyRequestRules(req)
-				headers = req.Headers
+				headers = p.handler.ruleApplier.ApplyRequestHeaderOnlyRules(headers)
 			}
 
 			// Strip content-length if body rules may modify payload length
@@ -673,12 +682,7 @@ func (p *h2Proxy) processHeaders(buf *bytes.Buffer, streamID uint32, block []byt
 
 			// Apply response header rules
 			if p.handler.ruleApplier != nil {
-				resp := &types.RawHTTP1Response{
-					StatusCode: stream.statusCode,
-					Headers:    headers,
-				}
-				resp = p.handler.ruleApplier.ApplyResponseRules(resp)
-				headers = resp.Headers
+				headers = p.handler.ruleApplier.ApplyResponseHeaderOnlyRules(headers)
 			}
 
 			// Strip content-length if body rules may modify payload length
@@ -710,6 +714,7 @@ func (p *h2Proxy) processHeaders(buf *bytes.Buffer, streamID uint32, block []byt
 					log.Printf("h2: body rule application failed: %v", err)
 					// Send RST_STREAM to destination to signal error
 					p.sendRSTStream(buf, dst, streamID, http2.ErrCodeInternal)
+					p.storeStreamInHistory(stream, reasonUpstreamError)
 					p.cleanupStream(streamID)
 					return
 				}
@@ -736,9 +741,15 @@ func (p *h2Proxy) processHeaders(buf *bytes.Buffer, streamID uint32, block []byt
 
 	p.writeHeadersFrame(buf, dst, streamID, encoded, endStream)
 
+	// Persist the response head so the flow is visible while its body streams.
+	// Skip when the stream already ended (no body); storeStreamInHistory stores it whole.
+	if !fromClient && !isTrailer && !isStreamClosed {
+		p.storeH2StreamHead(stream)
+	}
+
 	// Check if stream is complete (after unlock to avoid holding lock during history store)
 	if isStreamClosed {
-		p.storeStreamInHistory(stream)
+		p.storeStreamInHistory(stream, "")
 		p.cleanupStream(streamID)
 	}
 }
@@ -768,6 +779,9 @@ func (p *h2Proxy) handleDataFrame(buf *bytes.Buffer, f *http2.DataFrame, src, ds
 				framer := http2.NewFramer(buf, nil)
 				_ = framer.WriteRSTStream(streamID, http2.ErrCodeFlowControl)
 				src.enqueueWrite(p.ctx, buf.Bytes())
+				if s, ok := p.streams.get(streamID); ok {
+					p.storeStreamInHistory(s, reasonUpstreamError)
+				}
 				p.cleanupStream(streamID)
 			}
 		}
@@ -796,7 +810,7 @@ func (p *h2Proxy) handleDataFrame(buf *bytes.Buffer, f *http2.DataFrame, src, ds
 			p.sendWindowUpdates(buf, src, streamID, connUpd, streamUpd)
 		}
 		if endStream {
-			p.storeStreamInHistory(stream)
+			p.storeStreamInHistory(stream, "")
 			p.cleanupStream(streamID)
 		}
 		return
@@ -809,15 +823,24 @@ func (p *h2Proxy) handleDataFrame(buf *bytes.Buffer, f *http2.DataFrame, src, ds
 	stream.mu.Lock()
 	stream.lastActivity = time.Now()
 
-	// Copy to history buffer (limited to maxBodyBytes for storage)
-	p.copyToHistoryBufferLocked(stream, data, fromClient)
-
 	// Determine if this stream has already overflowed (switched to streaming)
 	var isOverflow bool
 	if fromClient {
 		isOverflow = stream.reqBodyOverflow
 	} else {
 		isOverflow = stream.respBodyOverflow
+	}
+
+	// Buffer the whole body only when rules need it: full_buffer, or a compressed
+	// body (no fragment is independently decodable). Otherwise stream, applying
+	// body rules per frame.
+	bufferMode := hasBodyRules && !isOverflow && (p.handler.fullBuffer || streamCompressedLocked(stream, fromClient))
+	streamRules := hasBodyRules && !isOverflow && !bufferMode
+
+	// History accumulates the raw frame now, except stream-rules mode where the
+	// mutated frame is appended after rules (below).
+	if !streamRules {
+		p.copyToHistoryBufferLocked(stream, data, fromClient)
 	}
 
 	// Capture data needed outside the lock for write operations
@@ -827,9 +850,9 @@ func (p *h2Proxy) handleDataFrame(buf *bytes.Buffer, f *http2.DataFrame, src, ds
 	// defers replenishment to the pump so in-flight data stays bounded.
 	var eagerConnUpd, eagerStreamUpd uint32
 
-	if hasBodyRules && !isOverflow {
-		// Buffer mode: accumulate full body for rule application. Replenish eagerly so
-		// the sender can deliver the whole body (bounded by maxBodyBytes) up front.
+	if bufferMode {
+		// Accumulate full body for rule application. Replenish eagerly so the sender
+		// can deliver the whole body (bounded by maxBodyBytes) up front.
 		eagerConnUpd, eagerStreamUpd = src.needsWindowUpdate(streamID)
 		overflow := p.copyToFullBufferLocked(stream, data, fromClient)
 
@@ -860,7 +883,7 @@ func (p *h2Proxy) handleDataFrame(buf *bytes.Buffer, f *http2.DataFrame, src, ds
 		}
 		// Don't forward DATA frames until we have the complete body (or overflow)
 	} else {
-		// Streaming mode: forward immediately (no body rules or overflow)
+		// Streaming: forward this frame (raw, or per-frame rules below)
 		writeData = data
 		writeEndStream = endStream
 	}
@@ -870,6 +893,8 @@ func (p *h2Proxy) handleDataFrame(buf *bytes.Buffer, f *http2.DataFrame, src, ds
 	if endStream {
 		isStreamClosed = stream.markEndStream(fromClient)
 	}
+	flowID := stream.flowID
+	captured := stream.captured
 	stream.mu.Unlock()
 
 	// Eager replenishment for buffering mode happens here (outside the stream lock)
@@ -884,12 +909,13 @@ func (p *h2Proxy) handleDataFrame(buf *bytes.Buffer, f *http2.DataFrame, src, ds
 	}
 
 	if applyRules {
-		// Apply body rules (may call ruleApplier which shouldn't hold stream lock)
+		// Apply body rules to the complete buffered body (may call ruleApplier which shouldn't hold stream lock)
 		body, err := p.applyBodyRules(stream, bodyForRules, fromClient)
 		if err != nil {
 			log.Printf("h2: body rule application failed: %v", err)
 			// Send RST_STREAM to destination to signal error
 			p.sendRSTStream(buf, dst, streamID, http2.ErrCodeInternal)
+			p.storeStreamInHistory(stream, reasonUpstreamError)
 			p.cleanupStream(streamID)
 			return
 		}
@@ -901,12 +927,31 @@ func (p *h2Proxy) handleDataFrame(buf *bytes.Buffer, f *http2.DataFrame, src, ds
 
 		// Send modified body
 		p.enqueueData(dst, streamID, body, true, false)
+	} else if streamRules {
+		// Per-frame body rules: mutate, store the mutated frame, forward
+		out, err := p.applyBodyRules(stream, data, fromClient)
+		if err != nil {
+			log.Printf("h2: body rule application failed: %v", err)
+			p.sendRSTStream(buf, dst, streamID, http2.ErrCodeInternal)
+			p.storeStreamInHistory(stream, reasonUpstreamError)
+			p.cleanupStream(streamID)
+			return
+		}
+		stream.mu.Lock()
+		p.copyToHistoryBufferLocked(stream, out, fromClient)
+		stream.mu.Unlock()
+		p.enqueueData(dst, streamID, out, writeEndStream, true)
 	} else if writeData != nil {
 		p.enqueueData(dst, streamID, writeData, writeEndStream, true)
 	}
 
+	// Grow the stored response flow as its body streams in (streaming modes only)
+	if captured && !fromClient && !bufferMode && !isStreamClosed {
+		p.maybeCompleteH2Stream(stream, flowID)
+	}
+
 	if isStreamClosed {
-		p.storeStreamInHistory(stream)
+		p.storeStreamInHistory(stream, "")
 		p.cleanupStream(streamID)
 	}
 }
@@ -933,6 +978,7 @@ func (p *h2Proxy) copyToHistoryBufferLocked(stream *h2Stream, data []byte, fromC
 	}
 
 	if buf.Len() >= maxBytes {
+		stream.respBodyHistTruncated = stream.respBodyHistTruncated || !fromClient
 		return // already at limit
 	}
 
@@ -941,6 +987,7 @@ func (p *h2Proxy) copyToHistoryBufferLocked(stream *h2Stream, data []byte, fromC
 		buf.Write(data)
 	} else {
 		buf.Write(data[:remaining])
+		stream.respBodyHistTruncated = stream.respBodyHistTruncated || !fromClient
 	}
 }
 
@@ -1020,6 +1067,7 @@ func (p *h2Proxy) updateHistoryWithModifiedBodyLocked(stream *h2Stream, body []b
 			stream.respBody.Write(body)
 		} else {
 			stream.respBody.Write(body[:maxBytes])
+			stream.respBodyHistTruncated = true
 		}
 	}
 }
@@ -1135,8 +1183,14 @@ func (p *h2Proxy) handleGoAwayFrame(buf *bytes.Buffer, f *http2.GoAwayFrame, dst
 	dst.enqueueWrite(p.ctx, buf.Bytes())
 }
 
-// handleRSTStreamFrame forwards RST_STREAM and cleans up stream.
-func (p *h2Proxy) handleRSTStreamFrame(buf *bytes.Buffer, f *http2.RSTStreamFrame, dst *h2Conn) {
+// handleRSTStreamFrame forwards RST_STREAM and cleans up stream. fromClient picks
+// the truncation reason recorded on a captured stream.
+func (p *h2Proxy) handleRSTStreamFrame(buf *bytes.Buffer, f *http2.RSTStreamFrame, dst *h2Conn, fromClient bool) {
+	reason := reasonUpstreamError
+	if fromClient {
+		reason = reasonClientDisconnect
+	}
+
 	// Reset is bidirectional: drop any DATA still queued for either pump
 	p.client.markStreamAborted(f.StreamID)
 	p.upstream.markStreamAborted(f.StreamID)
@@ -1146,12 +1200,9 @@ func (p *h2Proxy) handleRSTStreamFrame(buf *bytes.Buffer, f *http2.RSTStreamFram
 	if stream, exists := p.streams.get(f.StreamID); exists {
 		stream.mu.Lock()
 		intercepted := stream.discardClientBody
-		hasExchange := stream.method != "" && stream.statusCode != 0
 		stream.mu.Unlock()
 		if intercepted {
-			if hasExchange {
-				p.storeStreamInHistory(stream)
-			}
+			p.storeStreamInHistory(stream, reason)
 			p.cleanupStream(f.StreamID)
 			return
 		}
@@ -1165,12 +1216,7 @@ func (p *h2Proxy) handleRSTStreamFrame(buf *bytes.Buffer, f *http2.RSTStreamFram
 	// Store partial exchange before cleanup so a client-cancel after
 	// receiving the response still appears in history.
 	if stream, exists := p.streams.get(f.StreamID); exists {
-		stream.mu.Lock()
-		hasExchange := stream.method != "" && stream.statusCode != 0
-		stream.mu.Unlock()
-		if hasExchange {
-			p.storeStreamInHistory(stream)
-		}
+		p.storeStreamInHistory(stream, reason)
 	}
 
 	p.cleanupStream(f.StreamID)
@@ -1259,6 +1305,7 @@ func (p *h2Proxy) writeFrames(h *h2Conn, conn net.Conn) {
 	for {
 		select {
 		case <-p.ctx.Done():
+			p.flushRemaining(h, conn)
 			return
 		case <-h.closeCh:
 			return
@@ -1270,9 +1317,32 @@ func (p *h2Proxy) writeFrames(h *h2Conn, conn net.Conn) {
 				_ = conn.SetWriteDeadline(time.Now().Add(p.handler.timeouts.WriteTimeout))
 			}
 			if _, err := conn.Write(data); err != nil {
-				log.Printf("h2: write error: %v", err)
+				if !isConnClosedErr(err) {
+					select {
+					case <-p.ctx.Done(): // intentional shutdown; suppress
+					default:
+						log.Printf("h2: write error: %v", err)
+					}
+				}
 				return
 			}
+		}
+	}
+}
+
+// flushRemaining best-effort writes frames still queued at shutdown so control
+// frames (e.g. GOAWAY) reach the peer before the socket closes.
+func (p *h2Proxy) flushRemaining(h *h2Conn, conn net.Conn) {
+	deadline := time.Now().Add(shutdownFlushGrace)
+	for {
+		select {
+		case data := <-h.writeCh:
+			_ = conn.SetWriteDeadline(deadline)
+			if _, err := conn.Write(data); err != nil {
+				return
+			}
+		default:
+			return
 		}
 	}
 }
@@ -1427,6 +1497,10 @@ func (p *h2Proxy) pumpDataFrame(buf *bytes.Buffer, dst, src *h2Conn, item h2Work
 				src.markStreamAborted(streamID)
 				p.sendRSTStream(buf, dst, streamID, http2.ErrCodeFlowControl)
 				p.sendRSTStream(buf, src, streamID, http2.ErrCodeFlowControl)
+				if s, ok := p.streams.get(streamID); ok {
+					p.storeStreamInHistory(s, reasonUpstreamError)
+				}
+				p.cleanupStream(streamID)
 				return
 			case <-flowCh:
 				continue
@@ -1494,10 +1568,67 @@ func (p *h2Proxy) sendRSTStream(buf *bytes.Buffer, dst *h2Conn, streamID uint32,
 	dst.enqueueWrite(p.ctx, buf.Bytes())
 }
 
-// storeStreamInHistory stores a completed stream in history.
-func (p *h2Proxy) storeStreamInHistory(stream *h2Stream) {
-	// Lock stream while reading all data for history
+// storeStreamInHistory finalizes a stream, marking it truncated when reason is
+// non-empty. Safe to call from multiple teardown paths: repeat calls complete the
+// same flow rather than duplicating it, with the last reason winning.
+func (p *h2Proxy) storeStreamInHistory(stream *h2Stream, reason string) {
 	stream.mu.Lock()
+	defer stream.mu.Unlock()
+
+	ann := truncationAnnotations(reason, stream.respBodyHistTruncated)
+	if stream.flowID != "" {
+		p.handler.history.Complete(stream.flowID, stream.responseMessageLocked(), time.Now(), ann)
+		return
+	}
+	// no head stored: persist a whole flow only for a real exchange
+	if stream.method == "" || stream.statusCode == 0 {
+		return
+	}
+	flow := p.buildH2FlowLocked(stream)
+	flow.CompletedAt = time.Now()
+	flow.Annotations = ann
+	if !p.handler.history.ShouldCapture(flow) {
+		return
+	}
+	stream.flowID = p.handler.history.Store(flow)
+	stream.captured = true
+}
+
+// storeH2StreamHead persists the request and response head as an in-progress flow,
+// setting stream.flowID and stream.captured. No-op once stored or when filtered out.
+func (p *h2Proxy) storeH2StreamHead(stream *h2Stream) {
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	if stream.flowID != "" {
+		return
+	}
+	flow := p.buildH2FlowLocked(stream)
+	if !p.handler.history.ShouldCapture(flow) {
+		return
+	}
+	stream.flowID = p.handler.history.Store(flow)
+	stream.captured = true
+	stream.respFlush = newFlushThrottle()
+}
+
+// maybeCompleteH2Stream grows the stored response flow when the throttle is due.
+func (p *h2Proxy) maybeCompleteH2Stream(stream *h2Stream, flowID string) {
+	stream.mu.Lock()
+	now := time.Now()
+	if !stream.respFlush.should(stream.respBody.Len(), now) {
+		stream.mu.Unlock()
+		return
+	}
+	stream.respFlush.mark(stream.respBody.Len(), now)
+	resp := stream.responseMessageLocked()
+	stream.mu.Unlock()
+
+	p.handler.history.Complete(flowID, resp, time.Time{}, nil)
+}
+
+// buildH2FlowLocked assembles the flow record (request + response head/body) for a
+// stream. Caller must hold stream.mu.
+func (p *h2Proxy) buildH2FlowLocked(stream *h2Stream) *types.Flow {
 	scheme := stream.scheme
 	if scheme == "" {
 		scheme = types.SchemeHTTPS // h2 is always tunneled over TLS via CONNECT
@@ -1515,7 +1646,7 @@ func (p *h2Proxy) storeStreamInHistory(stream *h2Stream) {
 	)
 	reqHeaders = append(reqHeaders, stream.reqHeaders...)
 
-	flow := &types.Flow{
+	return &types.Flow{
 		Adapter:     types.ProtocolH2,
 		ProtocolTag: types.ProtocolH2,
 		Scheme:      scheme,
@@ -1524,20 +1655,27 @@ func (p *h2Proxy) storeStreamInHistory(stream *h2Stream) {
 			Headers: reqHeaders,
 			Body:    append([]byte(nil), stream.reqBody.Bytes()...), // copy to avoid holding reference
 		},
-		Response: &types.Message{
-			StatusCode: stream.statusCode,
-			Headers:    stream.respHeaders,
-			Body:       append([]byte(nil), stream.respBody.Bytes()...), // copy to avoid holding reference
-		},
-		StartedAt:   stream.startTime,
-		CompletedAt: time.Now(),
+		Response:  stream.responseMessageLocked(),
+		StartedAt: stream.startTime,
 	}
-	stream.mu.Unlock()
+}
 
-	if !p.handler.history.ShouldCapture(flow) {
-		return
+// responseMessageLocked builds a snapshot of the response side. Caller must hold stream.mu.
+func (s *h2Stream) responseMessageLocked() *types.Message {
+	return &types.Message{
+		StatusCode: s.statusCode,
+		Headers:    slices.Clone(s.respHeaders),
+		Body:       append([]byte(nil), s.respBody.Bytes()...), // copy to avoid holding reference
 	}
-	p.handler.history.Store(flow)
+}
+
+// streamCompressedLocked reports whether the streamed message carries a
+// Content-Encoding that prevents per-frame body rule application. Caller holds mu.
+func streamCompressedLocked(stream *h2Stream, fromClient bool) bool {
+	if fromClient {
+		return stream.reqHeaders.Get("content-encoding") != ""
+	}
+	return stream.respHeaders.Get("content-encoding") != ""
 }
 
 // sendInterceptedH2Response sends a canned response to the client for an intercepted request.
@@ -1580,7 +1718,7 @@ func (p *h2Proxy) sendInterceptedH2Response(buf *bytes.Buffer, stream *h2Stream,
 		return
 	}
 
-	p.storeStreamInHistory(stream)
+	p.storeStreamInHistory(stream, "")
 	p.cleanupStream(streamID)
 }
 
@@ -1616,6 +1754,7 @@ func (p *h2Proxy) cleanupStaleStreams() {
 					_ = framer.WriteRSTStream(streamID, http2.ErrCodeCancel)
 					p.upstream.enqueueWrite(p.ctx, buf.Bytes())
 
+					p.storeStreamInHistory(stream, reasonStreamIdle)
 					p.cleanupStream(streamID)
 				}
 			}

--- a/sectool/service/proxy/handler_http2_stream_test.go
+++ b/sectool/service/proxy/handler_http2_stream_test.go
@@ -1,0 +1,167 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-appsec/toolbox/sectool/service/store"
+)
+
+func TestHTTP2StreamingResponse(t *testing.T) {
+	t.Parallel()
+
+	gate := make(chan struct{})
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		_, _ = w.Write([]byte("data: one\n\n"))
+		flusher.Flush()
+		<-gate
+		_, _ = w.Write([]byte("data: two\n\n"))
+		flusher.Flush()
+	}))
+	upstream.TLS = &tls.Config{NextProtos: []string{"h2"}}
+	upstream.StartTLS()
+	t.Cleanup(upstream.Close)
+
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
+	require.NoError(t, err)
+	go func() { _ = proxy.Serve() }()
+	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
+	require.NoError(t, proxy.WaitReady(t.Context()))
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(proxy.CertManager().CACert())
+	transport := &http.Transport{
+		Proxy: http.ProxyURL(mustParseURL(t, "http://"+proxy.Addr())),
+		TLSClientConfig: &tls.Config{
+			RootCAs:            caPool,
+			InsecureSkipVerify: true,
+		},
+		ForceAttemptHTTP2: true,
+	}
+	client := &http.Client{Transport: transport}
+
+	req, err := http.NewRequestWithContext(t.Context(), "GET", upstream.URL+"/events", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	require.Equal(t, 2, resp.ProtoMajor)
+
+	received := &syncBuf{}
+	go func() { _, _ = io.Copy(received, resp.Body) }()
+
+	// First event reaches the client before the second is released
+	require.Eventually(t, func() bool {
+		return strings.Contains(received.String(), "data: one")
+	}, 3*time.Second, 10*time.Millisecond)
+	assert.NotContains(t, received.String(), "data: two")
+
+	// History shows the flow in progress with the partial body
+	var flowID string
+	require.Eventually(t, func() bool {
+		flows := proxy.History().Page(1, "")
+		if len(flows) != 1 || flows[0].Response == nil {
+			return false
+		}
+		flowID = flows[0].FlowID
+		return flows[0].CompletedAt.IsZero() && strings.Contains(string(flows[0].Response.Body), "one")
+	}, 3*time.Second, 10*time.Millisecond)
+
+	close(gate)
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(received.String(), "data: two")
+	}, 3*time.Second, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		flow, ok := proxy.History().Get(flowID)
+		if !ok || flow.Response == nil {
+			return false
+		}
+		body := string(flow.Response.Body)
+		return !flow.CompletedAt.IsZero() && strings.Contains(body, "one") && strings.Contains(body, "two")
+	}, 3*time.Second, 10*time.Millisecond)
+}
+
+func TestHTTP2StreamingClientCancelFinalizes(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		flusher := w.(http.Flusher)
+		_, _ = w.Write([]byte("data: one\n\n"))
+		flusher.Flush()
+		<-r.Context().Done() // hold the stream open until the client goes away
+	}))
+	upstream.TLS = &tls.Config{NextProtos: []string{"h2"}}
+	upstream.StartTLS()
+	t.Cleanup(upstream.Close)
+
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
+	require.NoError(t, err)
+	go func() { _ = proxy.Serve() }()
+	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
+	require.NoError(t, proxy.WaitReady(t.Context()))
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(proxy.CertManager().CACert())
+	transport := &http.Transport{
+		Proxy: http.ProxyURL(mustParseURL(t, "http://"+proxy.Addr())),
+		TLSClientConfig: &tls.Config{
+			RootCAs:            caPool,
+			InsecureSkipVerify: true,
+		},
+		ForceAttemptHTTP2: true,
+	}
+	client := &http.Client{Transport: transport}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	req, err := http.NewRequestWithContext(ctx, "GET", upstream.URL+"/events", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, 2, resp.ProtoMajor)
+
+	head := make([]byte, len("data: one\n\n"))
+	_, err = io.ReadFull(resp.Body, head)
+	require.NoError(t, err)
+	assert.Contains(t, string(head), "data: one")
+
+	// Flow is head-stored and in progress while the server holds the stream open
+	var flowID string
+	require.Eventually(t, func() bool {
+		flows := proxy.History().Page(1, "")
+		if len(flows) != 1 || flows[0].Response == nil {
+			return false
+		}
+		flowID = flows[0].FlowID
+		return flows[0].CompletedAt.IsZero()
+	}, 3*time.Second, 10*time.Millisecond)
+
+	// Cancel mid-stream: abnormal teardown must finalize and mark the flow truncated
+	cancel()
+	_ = resp.Body.Close()
+
+	require.Eventually(t, func() bool {
+		flow, ok := proxy.History().Get(flowID)
+		if !ok || flow.CompletedAt.IsZero() {
+			return false
+		}
+		return flow.Annotations[annStreamTruncated] == true
+	}, 5*time.Second, 20*time.Millisecond)
+}

--- a/sectool/service/proxy/handler_http2_test.go
+++ b/sectool/service/proxy/handler_http2_test.go
@@ -151,6 +151,20 @@ func (m *h2MockRuleApplier) ApplyResponseBodyOnlyRules(body []byte, headers type
 	return body
 }
 
+func (m *h2MockRuleApplier) ApplyRequestHeaderOnlyRules(headers types.Headers) types.Headers {
+	if m.reqHeaderMod != nil {
+		return m.reqHeaderMod(headers)
+	}
+	return headers
+}
+
+func (m *h2MockRuleApplier) ApplyResponseHeaderOnlyRules(headers types.Headers) types.Headers {
+	if m.respHeaderMod != nil {
+		return m.respHeaderMod(headers)
+	}
+	return headers
+}
+
 func TestApplyBodyRules(t *testing.T) {
 	t.Parallel()
 
@@ -268,43 +282,92 @@ func TestUpdateHistoryWithModifiedBody(t *testing.T) {
 func TestStoreStreamInHistory(t *testing.T) {
 	t.Parallel()
 
-	history := newHistoryStore(store.NewMemStorage())
-	handler := newHTTP2Handler(history, 1024, TimeoutConfig{})
-	stream := &h2Stream{
-		id:          1,
-		state:       streamClosed,
-		method:      "GET",
-		scheme:      "https",
-		authority:   "test.example.com",
-		path:        "/api/v1",
-		statusCode:  200,
-		startTime:   time.Now().Add(-100 * time.Millisecond),
-		reqHeaders:  []types.Header{{Name: "user-agent", Value: "test"}},
-		respHeaders: []types.Header{{Name: "content-type", Value: "application/json"}},
+	newStream := func() *h2Stream {
+		s := &h2Stream{
+			id:          1,
+			state:       streamClosed,
+			method:      "GET",
+			scheme:      "https",
+			authority:   "test.example.com",
+			path:        "/api/v1",
+			statusCode:  200,
+			startTime:   time.Now().Add(-100 * time.Millisecond),
+			reqHeaders:  []types.Header{{Name: "user-agent", Value: "test"}},
+			respHeaders: []types.Header{{Name: "content-type", Value: "application/json"}},
+		}
+		s.reqBody.WriteString("request body")
+		s.respBody.WriteString(`{"ok": true}`)
+		return s
 	}
-	stream.reqBody.WriteString("request body")
-	stream.respBody.WriteString(`{"ok": true}`)
-	p := &h2Proxy{
-		handler: handler,
-		streams: newStreamTracker(),
+	newProxy := func() (*h2Proxy, *HistoryStore) {
+		history := newHistoryStore(store.NewMemStorage())
+		return &h2Proxy{handler: newHTTP2Handler(history, 1024, TimeoutConfig{}), streams: newStreamTracker()}, history
 	}
 
-	p.storeStreamInHistory(stream)
+	t.Run("whole_store_clean", func(t *testing.T) {
+		p, history := newProxy()
+		p.storeStreamInHistory(newStream(), "")
 
-	assert.Equal(t, 1, history.Count())
+		require.Equal(t, 1, history.Count())
+		entry := firstEntry(t, history)
+		assert.Equal(t, "http/2", entry.ProtocolTag)
+		assert.Equal(t, "1", entry.GetRequestHeader(types.HeaderStreamID))
+		assert.Equal(t, "GET", entry.GetMethod())
+		assert.Equal(t, "test.example.com", entry.GetHost())
+		assert.Equal(t, "/api/v1", entry.GetPath())
+		assert.Equal(t, "request body", string(entry.Request.Body))
+		assert.Equal(t, `{"ok": true}`, string(entry.Response.Body))
+		assert.False(t, entry.CompletedAt.IsZero())
+		assert.Nil(t, entry.Annotations)
+	})
 
-	entry := firstEntry(t, history)
-	assert.Equal(t, "http/2", entry.ProtocolTag)
-	assert.Equal(t, "1", entry.GetRequestHeader(types.HeaderStreamID))
-	require.NotNil(t, entry.Request)
-	assert.Equal(t, "GET", entry.GetMethod())
-	assert.Equal(t, "https", entry.GetRequestHeader(":scheme"))
-	assert.Equal(t, "test.example.com", entry.GetHost())
-	assert.Equal(t, "/api/v1", entry.GetPath())
-	assert.Equal(t, "request body", string(entry.Request.Body))
-	require.NotNil(t, entry.Response)
-	assert.Equal(t, 200, entry.GetStatusCode())
-	assert.Equal(t, `{"ok": true}`, string(entry.Response.Body))
+	t.Run("truncated_reason", func(t *testing.T) {
+		p, history := newProxy()
+		p.storeStreamInHistory(newStream(), reasonUpstreamError)
+
+		entry := firstEntry(t, history)
+		assert.Equal(t, true, entry.Annotations[annStreamTruncated])
+		assert.Equal(t, reasonUpstreamError, entry.Annotations[annStreamReason])
+	})
+
+	t.Run("body_truncated_on_clean_close", func(t *testing.T) {
+		p, history := newProxy()
+		stream := newStream()
+		stream.respBodyHistTruncated = true
+		p.storeStreamInHistory(stream, "")
+
+		entry := firstEntry(t, history)
+		assert.Equal(t, true, entry.Annotations[annBodyTruncated])
+		_, truncated := entry.Annotations[annStreamTruncated]
+		assert.False(t, truncated)
+	})
+
+	t.Run("skip_request_only", func(t *testing.T) {
+		p, history := newProxy()
+		stream := newStream()
+		stream.statusCode = 0
+		p.storeStreamInHistory(stream, reasonConnClosed)
+
+		assert.Equal(t, 0, history.Count())
+	})
+
+	t.Run("idempotent_head_then_finalize", func(t *testing.T) {
+		p, history := newProxy()
+		stream := newStream()
+		stream.state = streamOpen
+		p.storeH2StreamHead(stream)
+		require.NotEmpty(t, stream.flowID)
+		flowID := stream.flowID
+
+		p.storeStreamInHistory(stream, reasonConnClosed)
+		p.storeStreamInHistory(stream, reasonConnClosed) // repeat teardown path
+
+		assert.Equal(t, 1, history.Count())
+		flow, ok := history.Get(flowID)
+		require.True(t, ok)
+		assert.False(t, flow.CompletedAt.IsZero())
+		assert.Equal(t, reasonConnClosed, flow.Annotations[annStreamReason])
+	})
 }
 
 func TestH2ConnConsumeRecvWindow(t *testing.T) {
@@ -542,7 +605,7 @@ func TestHTTP2ProxyEndToEnd(t *testing.T) {
 	})
 	t.Cleanup(testServer.Close)
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = proxy.Serve() }()
 	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -616,7 +679,7 @@ func TestHTTP2ProxyInterceptWithRequestBody(t *testing.T) {
 	server.StartTLS()
 	t.Cleanup(server.Close)
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = proxy.Serve() }()
 	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -677,7 +740,7 @@ func TestHTTP2ProxyHeaderRules(t *testing.T) {
 	})
 	t.Cleanup(testServer.Close)
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = proxy.Serve() }()
 	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -738,7 +801,7 @@ func TestHTTP2ProxyBidirectionalLargeBody(t *testing.T) {
 	})
 	t.Cleanup(testServer.Close)
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = proxy.Serve() }()
 	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -804,6 +867,43 @@ func TestPumpDataFrame(t *testing.T) {
 			h2WorkItem{kind: wiData, streamID: 1, data: []byte("hello"), endStream: true})
 		assert.Empty(t, dst.writeCh)
 	})
+}
+
+func TestFlushRemaining(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	srv, cli := net.Pipe()
+	t.Cleanup(func() { _ = srv.Close(); _ = cli.Close() })
+
+	p := &h2Proxy{
+		ctx:     ctx,
+		cancel:  cancel,
+		handler: newHTTP2Handler(newHistoryStore(store.NewMemStorage()), 1024, TimeoutConfig{}),
+	}
+	h := newH2Conn(srv)
+
+	// queue frames, then cancel so writeFrames drains via flushRemaining
+	frames := [][]byte{[]byte("frame-one"), []byte("frame-two"), []byte("frame-three")}
+	for _, f := range frames {
+		require.True(t, h.enqueueWrite(ctx, f))
+	}
+	want := bytes.Join(frames, nil)
+	cancel()
+
+	p.wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.writeFrames(h, srv)
+	}()
+
+	got := make([]byte, len(want))
+	_, err := io.ReadFull(cli, got)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	<-done
 }
 
 func newHTTP2TestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {

--- a/sectool/service/proxy/history_stream.go
+++ b/sectool/service/proxy/history_stream.go
@@ -1,0 +1,69 @@
+package proxy
+
+import "time"
+
+const (
+	// streamFlushBytes coalesces history writes: flush once this many new body bytes accumulate.
+	streamFlushBytes = 64 << 10
+	// streamFlushInterval coalesces history writes: flush at least this often while data trickles.
+	streamFlushInterval = 250 * time.Millisecond
+)
+
+// Annotation keys and reasons recorded on a finalized streaming flow.
+const (
+	annStreamTruncated     = "stream_truncated"          // stream ended before the body completed
+	annStreamReason        = "stream_reason"             // why the stream was truncated
+	annBodyTruncated       = "body_truncated_in_history" // stored body hit maxBodyBytes; wire was complete
+	reasonClientDisconnect = "client_disconnect"
+	reasonUpstreamError    = "upstream_error"
+	reasonStreamIdle       = "stream_idle" // stream reaped after idle timeout
+	reasonConnClosed       = "conn_closed" // connection torn down with the stream still open
+)
+
+// flushThrottle gates coalesced two-phase history writes during a streaming
+// response. Wire forwarding is always per-unit; only persistence is throttled,
+// so a poller sees a slightly-stale snapshot with no fidelity cost.
+type flushThrottle struct {
+	minBytes    int           // byte-delta threshold since the last flush
+	minInterval time.Duration // time threshold since the last flush
+	lastLen     int           // body length at the last flush
+	lastAt      time.Time     // wall-clock of the last flush
+}
+
+// newFlushThrottle returns a throttle using the default byte and interval thresholds.
+func newFlushThrottle() flushThrottle {
+	return flushThrottle{minBytes: streamFlushBytes, minInterval: streamFlushInterval}
+}
+
+// should reports whether a flush is due at body length curLen and time now,
+// based on bytes added or time elapsed since the last mark. The first call
+// (before any mark) is always due, for prompt initial visibility.
+func (t *flushThrottle) should(curLen int, now time.Time) bool {
+	if t.lastAt.IsZero() || curLen-t.lastLen >= t.minBytes {
+		return true
+	}
+	return now.Sub(t.lastAt) >= t.minInterval
+}
+
+// mark records a flush at body length curLen and time now.
+func (t *flushThrottle) mark(curLen int, now time.Time) {
+	t.lastLen = curLen
+	t.lastAt = now
+}
+
+// truncationAnnotations builds finalize-time annotations for a streamed flow,
+// or nil when the stream was neither truncated nor body-capped.
+func truncationAnnotations(reason string, bodyTruncated bool) map[string]any {
+	if reason == "" && !bodyTruncated {
+		return nil
+	}
+	ann := make(map[string]any, 3)
+	if reason != "" {
+		ann[annStreamTruncated] = true
+		ann[annStreamReason] = reason
+	}
+	if bodyTruncated {
+		ann[annBodyTruncated] = true
+	}
+	return ann
+}

--- a/sectool/service/proxy/history_stream_test.go
+++ b/sectool/service/proxy/history_stream_test.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlushThrottleShould(t *testing.T) {
+	t.Parallel()
+
+	base := time.Unix(1700000000, 0)
+
+	t.Run("first_call_always_due", func(t *testing.T) {
+		tr := flushThrottle{minBytes: 1024, minInterval: time.Second}
+		assert.True(t, tr.should(0, base))
+	})
+
+	t.Run("byte_threshold", func(t *testing.T) {
+		tr := flushThrottle{minBytes: 1024, minInterval: time.Second}
+		tr.mark(0, base)
+		assert.False(t, tr.should(1023, base))
+		assert.True(t, tr.should(1024, base))
+	})
+
+	t.Run("time_threshold", func(t *testing.T) {
+		tr := flushThrottle{minBytes: 1024, minInterval: time.Second}
+		tr.mark(0, base)
+		assert.False(t, tr.should(10, base.Add(999*time.Millisecond)))
+		assert.True(t, tr.should(10, base.Add(time.Second)))
+	})
+
+	t.Run("mark_resets_baseline", func(t *testing.T) {
+		tr := flushThrottle{minBytes: 1024, minInterval: time.Second}
+		tr.mark(0, base)
+		tr.mark(2000, base.Add(2*time.Second))
+		assert.False(t, tr.should(2500, base.Add(2*time.Second)))
+	})
+}

--- a/sectool/service/proxy/parser.go
+++ b/sectool/service/proxy/parser.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -22,6 +23,9 @@ var (
 // initialBodyAlloc caps the up-front buffer reserved before reading a body of
 // declared length; the buffer grows on demand as bytes arrive.
 const initialBodyAlloc = 8192
+
+// streamReadChunk is the per-read buffer size used while streaming a body.
+const streamReadChunk = 32 << 10
 
 // ParseRequest parses an HTTP/1.1 request from the reader.
 // Returns error only for truly unparseable input.
@@ -100,46 +104,26 @@ func chunksBareFlags(chunks []types.ChunkFrame) (bareLF, bareCR bool) {
 	return bareLF, bareCR
 }
 
+// bodyUnitFunc receives one streamed body unit: decoded holds the logical bytes
+// (chunk data or raw read), wire holds the bytes to forward verbatim (a
+// reconstructed chunk frame, or the same as decoded for unframed bodies). Both
+// slices are valid only for the duration of the call. A non-nil return aborts.
+type bodyUnitFunc func(decoded, wire []byte) error
+
 // parseResponse parses an HTTP/1.1 response from the reader.
 // The request method is needed to determine body handling for HEAD responses.
 func parseResponse(r io.Reader, requestMethod string) (*types.RawHTTP1Response, error) {
 	br := bufio.NewReader(r)
 
-	line, statusLineEnding, err := readLineWithEnding(br)
-	if err != nil {
-		if errors.Is(err, io.EOF) && len(line) == 0 {
-			return nil, ErrEmptyResponse
-		} else if len(line) == 0 {
-			return nil, err
-		}
-	}
-
-	version, code, text, err := parseStatusLine(line)
+	resp, bodyExpected, usedBareLF, usedBareCR, err := parseResponseHead(br, requestMethod)
 	if err != nil {
 		return nil, err
 	}
-
-	resp := &types.RawHTTP1Response{
-		Version:          version,
-		StatusCode:       code,
-		StatusText:       text,
-		StatusLineEnding: statusLineEnding,
-	}
-
-	var headersBareLF, headersBareCR bool
-	if resp.Headers, headersBareLF, headersBareCR, resp.HeaderBlockEnding, err = readHeadersWithWire(br); err != nil && !errors.Is(err, io.EOF) {
-		return nil, err
-	}
-
-	// headersBare* already cover HeaderBlockEnding's terminator
-	usedBareLF := statusLineEnding == types.EndingBareLF || headersBareLF
-	usedBareCR := statusLineEnding == types.EndingBareCR || headersBareCR
 
 	var wasChunked bool
-	// HEAD and 1xx/204/304 responses have no body
-	if requestMethod != "HEAD" && code >= 200 && code != 204 && code != 304 {
+	if bodyExpected {
 		var trailersBareLF, trailersBareCR bool
-		if resp.Body, resp.Trailers, wasChunked, resp.Chunks, trailersBareLF, trailersBareCR, err = readResponseBodyWithWire(br, resp); err != nil && !errors.Is(err, io.EOF) {
+		if resp.Body, resp.Trailers, wasChunked, resp.Chunks, trailersBareLF, trailersBareCR, err = readResponseBodyWithWire(br, resp, nil); err != nil && !errors.Is(err, io.EOF) {
 			return nil, err
 		}
 		chunksBareLF, chunksBareCR := chunksBareFlags(resp.Chunks)
@@ -158,6 +142,45 @@ func parseResponse(r io.Reader, requestMethod string) (*types.RawHTTP1Response, 
 	return resp, nil
 }
 
+// parseResponseHead parses the status line and headers of an HTTP/1.1 response,
+// leaving the body unread on br. bodyExpected is false for HEAD, 1xx, 204, and
+// 304 (no message body). headBareLF/headBareCR report bare terminators seen in
+// the status line or header block. On success err is nil even if the header
+// block ended at EOF.
+func parseResponseHead(br *bufio.Reader, requestMethod string) (resp *types.RawHTTP1Response, bodyExpected, headBareLF, headBareCR bool, err error) {
+	line, statusLineEnding, lerr := readLineWithEnding(br)
+	if lerr != nil {
+		if errors.Is(lerr, io.EOF) && len(line) == 0 {
+			return nil, false, false, false, ErrEmptyResponse
+		} else if len(line) == 0 {
+			return nil, false, false, false, lerr
+		}
+	}
+
+	version, code, text, perr := parseStatusLine(line)
+	if perr != nil {
+		return nil, false, false, false, perr
+	}
+
+	resp = &types.RawHTTP1Response{
+		Version:          version,
+		StatusCode:       code,
+		StatusText:       text,
+		StatusLineEnding: statusLineEnding,
+	}
+
+	if resp.Headers, headBareLF, headBareCR, resp.HeaderBlockEnding, err = readHeadersWithWire(br); err != nil && !errors.Is(err, io.EOF) {
+		return nil, false, false, false, err
+	}
+
+	// status-line terminator folds into the head bare flags
+	headBareLF = headBareLF || statusLineEnding == types.EndingBareLF
+	headBareCR = headBareCR || statusLineEnding == types.EndingBareCR
+	// HEAD and 1xx/204/304 responses have no body
+	bodyExpected = requestMethod != "HEAD" && code >= 200 && code != 204 && code != 304
+	return resp, bodyExpected, headBareLF, headBareCR, nil
+}
+
 // readFinalResponse reads responses from br until a final (>=200) one, returning any
 // preceding interim 1xx responses and the final response. 101 is treated as final.
 // onInterim, when non-nil, is called for each interim response as it is read.
@@ -173,6 +196,33 @@ func readFinalResponse(br *bufio.Reader, requestMethod string, onInterim func(*t
 		if onInterim != nil {
 			if werr := onInterim(resp); werr != nil {
 				return interim, nil, werr
+			}
+		}
+		interim = append(interim, resp)
+	}
+}
+
+// readFinalResponseHead reads responses from br until a final (non-1xx, or 101)
+// one, returning any preceding interim 1xx responses and the final response's
+// head with its body left unread on br. bodyExpected reports whether the final
+// response has a body to stream; headBareLF/headBareCR report bare terminators
+// in the final head so the caller can assemble Wire after streaming the body.
+// onInterim, when non-nil, is called for each interim response.
+func readFinalResponseHead(br *bufio.Reader, requestMethod string, onInterim func(*types.RawHTTP1Response) error) (interim []*types.RawHTTP1Response, final *types.RawHTTP1Response, bodyExpected, headBareLF, headBareCR bool, err error) {
+	for {
+		resp, be, hlf, hcr, perr := parseResponseHead(br, requestMethod)
+		if perr != nil {
+			return interim, nil, false, false, false, perr
+		} else if resp.StatusCode < 100 || resp.StatusCode >= 200 || resp.StatusCode == 101 {
+			return interim, resp, be, hlf, hcr, nil
+		}
+		// interim 1xx has no body; preserve its bare-ending fidelity before forwarding
+		if hlf || hcr {
+			resp.Wire = &types.WireFormat{UsedBareLF: hlf, UsedBareCR: hcr}
+		}
+		if onInterim != nil {
+			if werr := onInterim(resp); werr != nil {
+				return interim, nil, false, false, false, werr
 			}
 		}
 		interim = append(interim, resp)
@@ -349,7 +399,7 @@ func readRequestBodyWithWire(br *bufio.Reader, req *types.RawHTTP1Request) (body
 	// Check for chunked encoding first (takes precedence over Content-Length)
 	te := req.GetHeader("Transfer-Encoding")
 	if strings.Contains(strings.ToLower(te), "chunked") {
-		body, trailers, chunks, trailersBareLF, trailersBareCR, err = readChunkedBody(br)
+		body, trailers, chunks, trailersBareLF, trailersBareCR, err = readChunkedBody(br, nil)
 		return body, trailers, true, chunks, trailersBareLF, trailersBareCR, err
 	}
 
@@ -371,39 +421,96 @@ func readRequestBodyWithWire(br *bufio.Reader, req *types.RawHTTP1Request) (body
 // readResponseBodyWithWire reads the response body and returns wasChunked, per-chunk
 // framing, and bare-LF/CR flags observed inside trailer lines. It sets
 // resp.CloseDelimited when the body is framed by connection close.
-func readResponseBodyWithWire(br *bufio.Reader, resp *types.RawHTTP1Response) (body, trailers []byte, wasChunked bool, chunks []types.ChunkFrame, trailersBareLF, trailersBareCR bool, err error) {
+func readResponseBodyWithWire(br *bufio.Reader, resp *types.RawHTTP1Response, onUnit bodyUnitFunc) (body, trailers []byte, wasChunked bool, chunks []types.ChunkFrame, trailersBareLF, trailersBareCR bool, err error) {
 	te := resp.GetHeader("Transfer-Encoding")
 	if strings.Contains(strings.ToLower(te), "chunked") {
-		body, trailers, chunks, trailersBareLF, trailersBareCR, err = readChunkedBody(br)
+		body, trailers, chunks, trailersBareLF, trailersBareCR, err = readChunkedBody(br, onUnit)
 		return body, trailers, true, chunks, trailersBareLF, trailersBareCR, err
 	}
 
 	clStr := resp.GetHeader("Content-Length")
 	if clStr != "" {
-		cl, err := strconv.ParseInt(clStr, 10, 64)
-		if err != nil || cl < 0 {
+		cl, perr := strconv.ParseInt(clStr, 10, 64)
+		if perr != nil || cl < 0 {
 			// Invalid CL, try reading to EOF
 			resp.CloseDelimited = true
-			body, err := io.ReadAll(br)
+			body, err = streamBody(br, -1, onUnit)
 			return body, nil, false, nil, false, false, err
 		} else if cl == 0 {
 			return nil, nil, false, nil, false, false, nil
 		}
-		buf := bytes.NewBuffer(make([]byte, 0, min(cl, int64(initialBodyAlloc))))
-		_, err = io.Copy(buf, io.LimitReader(br, cl))
-		return buf.Bytes(), nil, false, nil, false, false, err
+		body, err = streamBody(br, cl, onUnit)
+		return body, nil, false, nil, false, false, err
 	}
 
 	// No Content-Length or chunked: read until EOF (body delimited by connection close)
 	resp.CloseDelimited = true
-	body, err = io.ReadAll(br)
+	body, err = streamBody(br, -1, onUnit)
 	return body, nil, false, nil, false, false, err
+}
+
+// streamBody reads the body from br: exactly limit bytes, or to EOF when limit < 0.
+// When onUnit is nil it accumulates and returns the whole body; otherwise it
+// invokes onUnit per read (decoded == wire for an unframed body) and returns a
+// nil body, leaving accumulation to the caller. EOF ends the read cleanly; any
+// other read error is returned.
+func streamBody(br *bufio.Reader, limit int64, onUnit bodyUnitFunc) ([]byte, error) {
+	var out *bytes.Buffer
+	if onUnit == nil {
+		if limit > 0 {
+			// int64 cap is bounded by the initialBodyAlloc constant; no narrowing conversion
+			out = bytes.NewBuffer(make([]byte, 0, min(limit, int64(initialBodyAlloc))))
+		} else {
+			out = &bytes.Buffer{}
+		}
+	}
+
+	buf := make([]byte, streamReadChunk)
+	remaining := limit
+	for limit < 0 || remaining > 0 {
+		readLen := int64(streamReadChunk)
+		if limit >= 0 && remaining < readLen {
+			readLen = remaining
+		}
+		rn, rerr := br.Read(buf[:readLen])
+		if rn > 0 {
+			if out != nil {
+				out.Write(buf[:rn])
+			}
+			if onUnit != nil {
+				if cerr := onUnit(buf[:rn], buf[:rn]); cerr != nil {
+					return nil, cerr
+				}
+			}
+			remaining -= int64(rn)
+		}
+		if rerr != nil {
+			if errors.Is(rerr, io.EOF) {
+				break
+			}
+			if out != nil {
+				return out.Bytes(), rerr
+			}
+			return nil, rerr
+		}
+	}
+
+	if out != nil {
+		return out.Bytes(), nil
+	}
+	return nil, nil
 }
 
 // readChunkedBody reads chunked transfer encoding, returning the decoded body,
 // trailers, per-chunk framing, and bare-LF/CR flags observed in trailer lines.
-func readChunkedBody(br *bufio.Reader) (body, trailers []byte, chunks []types.ChunkFrame, trailersBareLF, trailersBareCR bool, err error) {
+// When onUnit is non-nil each data chunk is emitted (decoded data plus its
+// reconstructed wire frame) instead of accumulated, so the returned body and
+// data-chunk frames are empty; the terminal 0-chunk frame and trailers still return.
+func readChunkedBody(br *bufio.Reader, onUnit bodyUnitFunc) (body, trailers []byte, chunks []types.ChunkFrame, trailersBareLF, trailersBareCR bool, err error) {
 	var bodyBuf bytes.Buffer
+	// reused across chunks in streaming mode; onUnit consumes synchronously
+	var dataBuf []byte
+	var wireBuf bytes.Buffer
 
 	for {
 		sizeLine, sizeEnding, readErr := readLineWithEnding(br)
@@ -419,7 +526,7 @@ func readChunkedBody(br *bufio.Reader) (body, trailers []byte, chunks []types.Ch
 		sizeStr = strings.TrimSpace(sizeStr)
 
 		size, parseErr := strconv.ParseInt(sizeStr, 16, 64)
-		if parseErr != nil {
+		if parseErr != nil || size < 0 || size > math.MaxInt {
 			// Preserve the bad size line; do not drain further so any pipelined request remains
 			chunks = append(chunks, types.ChunkFrame{
 				SizeLine:   slices.Clone(sizeLine),
@@ -429,21 +536,39 @@ func readChunkedBody(br *bufio.Reader) (body, trailers []byte, chunks []types.Ch
 			return bodyBuf.Bytes(), nil, chunks, trailersBareLF, trailersBareCR, nil
 		}
 
-		// Preserve original size-line bytes (including chunk extensions)
-		sizeLineCopy := slices.Clone(sizeLine)
-
 		if size == 0 {
 			// Final chunk terminator; read trailers next
 			// DataEnding of the 0-chunk records the blank-line terminator that closes the trailer block
 			var trailerBlockEnd types.LineEnding
 			trailers, trailerBlockEnd, trailersBareLF, trailersBareCR, _ = readTrailers(br)
 			chunks = append(chunks, types.ChunkFrame{
-				SizeLine:   sizeLineCopy,
+				SizeLine:   slices.Clone(sizeLine),
 				SizeEnding: sizeEnding,
 				Size:       0,
 				DataEnding: trailerBlockEnd,
 			})
 			return bodyBuf.Bytes(), trailers, chunks, trailersBareLF, trailersBareCR, nil
+		}
+
+		if onUnit != nil {
+			// Streaming: read the data out, emit its wire frame, don't accumulate
+			if cap(dataBuf) < int(size) {
+				dataBuf = make([]byte, size)
+			}
+			dataBuf = dataBuf[:size]
+			if _, err = io.ReadFull(br, dataBuf); err != nil {
+				return nil, nil, chunks, trailersBareLF, trailersBareCR, err
+			}
+			_, dataEnding, _ := readLineWithEnding(br)
+			wireBuf.Reset()
+			wireBuf.Write(sizeLine)
+			wireBuf.WriteString(sizeEnding.Bytes())
+			wireBuf.Write(dataBuf)
+			wireBuf.WriteString(dataEnding.Bytes())
+			if cerr := onUnit(dataBuf, wireBuf.Bytes()); cerr != nil {
+				return nil, nil, chunks, trailersBareLF, trailersBareCR, cerr
+			}
+			continue
 		}
 
 		if _, err = io.CopyN(&bodyBuf, br, size); err != nil {
@@ -454,7 +579,7 @@ func readChunkedBody(br *bufio.Reader) (body, trailers []byte, chunks []types.Ch
 		_, dataEnding, _ := readLineWithEnding(br)
 
 		chunks = append(chunks, types.ChunkFrame{
-			SizeLine:   sizeLineCopy,
+			SizeLine:   slices.Clone(sizeLine),
 			SizeEnding: sizeEnding,
 			Size:       int(size),
 			DataEnding: dataEnding,

--- a/sectool/service/proxy/parser_test.go
+++ b/sectool/service/proxy/parser_test.go
@@ -1607,7 +1607,7 @@ func TestReadChunkedBody(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			br := bufio.NewReader(bytes.NewReader([]byte(tt.input)))
-			body, trailers, _, _, _, err := readChunkedBody(br)
+			body, trailers, _, _, _, err := readChunkedBody(br, nil)
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantBody, string(body))
@@ -1615,11 +1615,38 @@ func TestReadChunkedBody(t *testing.T) {
 		})
 	}
 
+	// Streaming mode reuses per-chunk scratch buffers; a compliant consumer copies
+	// each unit synchronously, so multiple chunks must not corrupt one another.
+	t.Run("streaming_onunit", func(t *testing.T) {
+		input := "5\r\nHello\r\n6;ext=v\r\n World\r\n1\r\n!\r\n0\r\nX: y\r\n\r\n"
+		br := bufio.NewReader(bytes.NewReader([]byte(input)))
+
+		var decoded, wire bytes.Buffer
+		body, trailers, chunks, _, _, err := readChunkedBody(br, func(d, w []byte) error {
+			decoded.Write(d) // copy, mirroring the real consumer
+			wire.Write(w)
+			return nil
+		})
+		require.NoError(t, err)
+
+		assert.Empty(t, body) // streaming does not accumulate
+		assert.Equal(t, "Hello World!", decoded.String())
+		// wire frames plus the terminal 0-chunk reconstruct the original input verbatim
+		var full bytes.Buffer
+		full.Write(wire.Bytes())
+		require.Len(t, chunks, 1)
+		full.Write(chunks[0].SizeLine)
+		full.WriteString(chunks[0].SizeEnding.Bytes())
+		full.Write(trailers)
+		full.WriteString(chunks[0].DataEnding.Bytes())
+		assert.Equal(t, input, full.String())
+	})
+
 	// edge cases
 	t.Run("invalid_hex_chunk_size", func(t *testing.T) {
 		input := "0x5\r\nhello\r\n0\r\n\r\n"
 		br := bufio.NewReader(bytes.NewReader([]byte(input)))
-		body, _, chunks, _, _, err := readChunkedBody(br)
+		body, _, chunks, _, _, err := readChunkedBody(br, nil)
 		require.NoError(t, err)
 		assert.Empty(t, body)
 		require.Len(t, chunks, 1)
@@ -1631,7 +1658,7 @@ func TestReadChunkedBody(t *testing.T) {
 		// Very large chunk size - should handle gracefully
 		input := "FFFFF\r\n" // Declares ~1MB chunk but has no data
 		br := bufio.NewReader(bytes.NewReader([]byte(input)))
-		_, _, _, _, _, err := readChunkedBody(br)
+		_, _, _, _, _, err := readChunkedBody(br, nil)
 		// Should error due to missing data
 		assert.Error(t, err)
 	})
@@ -1639,7 +1666,7 @@ func TestReadChunkedBody(t *testing.T) {
 	t.Run("chunk_extension_with_quotes", func(t *testing.T) {
 		input := "5;name=\"val;ue\"\r\nHello\r\n0\r\n\r\n"
 		br := bufio.NewReader(bytes.NewReader([]byte(input)))
-		body, _, chunks, _, _, err := readChunkedBody(br)
+		body, _, chunks, _, _, err := readChunkedBody(br, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "Hello", string(body))
 		require.GreaterOrEqual(t, len(chunks), 1)
@@ -1649,7 +1676,7 @@ func TestReadChunkedBody(t *testing.T) {
 	t.Run("bare_lf_in_chunked", func(t *testing.T) {
 		input := "5\nHello\n0\n\n"
 		br := bufio.NewReader(bytes.NewReader([]byte(input)))
-		body, _, chunks, _, _, err := readChunkedBody(br)
+		body, _, chunks, _, _, err := readChunkedBody(br, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "Hello", string(body))
 		bareLF, bareCR := chunksBareFlags(chunks)
@@ -1661,7 +1688,7 @@ func TestReadChunkedBody(t *testing.T) {
 		// Chunk-size line terminated with bare CR - classic desync primitive
 		input := "5\rHello\r\n0\r\n\r\n"
 		br := bufio.NewReader(bytes.NewReader([]byte(input)))
-		body, _, chunks, _, _, err := readChunkedBody(br)
+		body, _, chunks, _, _, err := readChunkedBody(br, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "Hello", string(body))
 		bareLF, bareCR := chunksBareFlags(chunks)
@@ -1673,7 +1700,7 @@ func TestReadChunkedBody(t *testing.T) {
 		// Trailer header uses bare CR terminator; flag and trailer bytes both preserve it
 		input := "5\r\nHello\r\n0\r\nX-Trailer: end\r\r\n"
 		br := bufio.NewReader(bytes.NewReader([]byte(input)))
-		body, trailers, _, trailersBareLF, trailersBareCR, err := readChunkedBody(br)
+		body, trailers, _, trailersBareLF, trailersBareCR, err := readChunkedBody(br, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "Hello", string(body))
 		assert.False(t, trailersBareLF)
@@ -1686,7 +1713,7 @@ func TestReadChunkedBody(t *testing.T) {
 		// a bare-LF trailer line must serialize back as bare LF, not CRLF
 		input := "5\r\nHello\r\n0\r\nX-Trailer: end\n\r\n"
 		br := bufio.NewReader(bytes.NewReader([]byte(input)))
-		_, trailers, _, trailersBareLF, _, err := readChunkedBody(br)
+		_, trailers, _, trailersBareLF, _, err := readChunkedBody(br, nil)
 		require.NoError(t, err)
 		assert.True(t, trailersBareLF)
 		assert.Equal(t, "X-Trailer: end\n", string(trailers))

--- a/sectool/service/proxy/registry_test.go
+++ b/sectool/service/proxy/registry_test.go
@@ -128,7 +128,7 @@ func TestClaimUpgrade(t *testing.T) {
 func TestServeRejectsH2C(t *testing.T) {
 	t.Parallel()
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = proxy.Serve() }()
 	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })

--- a/sectool/service/proxy/server.go
+++ b/sectool/service/proxy/server.go
@@ -64,7 +64,8 @@ type ProxyServer struct {
 // configDir is the directory for CA certificates (e.g., ~/.sectool).
 // maxBodyBytes limits request and response body sizes stored in history.
 // historyStorage is the storage backend for proxy history entries.
-func NewProxyServer(port int, configDir string, maxBodyBytes int, historyStorage store.Storage, timeouts TimeoutConfig) (*ProxyServer, error) {
+// fullBuffer forces whole-body buffering for response body rules instead of streaming.
+func NewProxyServer(port int, configDir string, maxBodyBytes int, historyStorage store.Storage, timeouts TimeoutConfig, fullBuffer bool) (*ProxyServer, error) {
 	certManager, err := newCertManager(configDir)
 	if err != nil {
 		return nil, fmt.Errorf("create cert manager: %w", err)
@@ -86,9 +87,11 @@ func NewProxyServer(port int, configDir string, maxBodyBytes int, historyStorage
 		history:      history,
 		maxBodyBytes: maxBodyBytes,
 		timeouts:     timeouts,
+		fullBuffer:   fullBuffer,
 	}
 
 	http2Handler := newHTTP2Handler(history, maxBodyBytes, timeouts)
+	http2Handler.fullBuffer = fullBuffer
 
 	connectHandler := newConnectHandler(certManager, http1Handler, http2Handler, history, maxBodyBytes, timeouts)
 

--- a/sectool/service/proxy/server_test.go
+++ b/sectool/service/proxy/server_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"io"
@@ -20,6 +21,19 @@ import (
 	"github.com/go-appsec/toolbox/sectool/service/store"
 	"github.com/go-appsec/toolbox/sectool/service/testutil"
 )
+
+// readResponse reads one full HTTP/1.1 response from conn and returns its status
+// line plus body, tolerating head/body arriving in separate reads.
+func readResponse(t *testing.T, conn net.Conn) string {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.Status + string(body)
+}
 
 func TestServe(t *testing.T) {
 	// test cases are t.Parallel() instead due to speed
@@ -119,7 +133,7 @@ func TestServe(t *testing.T) {
 	t.Run("connect_request", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		go func() { _ = proxy.Serve() }()
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -145,7 +159,7 @@ func TestServe(t *testing.T) {
 	t.Run("malformed_request_line", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		go func() { _ = proxy.Serve() }()
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -200,7 +214,7 @@ func TestServe(t *testing.T) {
 func TestShutdown(t *testing.T) {
 	t.Parallel()
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	go func() { _ = proxy.Serve() }()
@@ -229,7 +243,7 @@ func TestShutdown(t *testing.T) {
 func setupProxyClient(t *testing.T) (*ProxyServer, *http.Client) {
 	t.Helper()
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = proxy.Serve() }()
 	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -250,7 +264,7 @@ func TestProxyServerComponents(t *testing.T) {
 	t.Run("addr_before_serve", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
 
@@ -263,7 +277,7 @@ func TestProxyServerComponents(t *testing.T) {
 	t.Run("history_accessible", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
 
@@ -275,7 +289,7 @@ func TestProxyServerComponents(t *testing.T) {
 	t.Run("cert_manager_accessible", func(t *testing.T) {
 		t.Parallel()
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
 
@@ -294,7 +308,7 @@ func TestConcurrentConnections(t *testing.T) {
 	}))
 	t.Cleanup(testServer.Close)
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = proxy.Serve() }()
 	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -353,7 +367,7 @@ func TestConnectionGoroutineLeak(t *testing.T) {
 	}))
 	t.Cleanup(testServer.Close)
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = proxy.Serve() }()
 	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -437,7 +451,7 @@ func TestProxyServerRuleApplier(t *testing.T) {
 	}))
 	t.Cleanup(testServer.Close)
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 	go func() { _ = proxy.Serve() }()
 	t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -486,6 +500,16 @@ func (t *trackingRuleApplier) ApplyResponseBodyOnlyRules(body []byte, headers ty
 	return body
 }
 
+func (t *trackingRuleApplier) ApplyRequestHeaderOnlyRules(headers types.Headers) types.Headers {
+	t.requestCalled.Store(true)
+	return headers
+}
+
+func (t *trackingRuleApplier) ApplyResponseHeaderOnlyRules(headers types.Headers) types.Headers {
+	t.responseCalled.Store(true)
+	return headers
+}
+
 func (t *trackingRuleApplier) ApplyWSRules(payload []byte, direction string) []byte {
 	return payload
 }
@@ -497,7 +521,7 @@ func (t *trackingRuleApplier) HasBodyRules(isRequest bool) bool {
 func TestServeContextCancellation(t *testing.T) {
 	t.Parallel()
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -525,7 +549,7 @@ func TestServeContextCancellation(t *testing.T) {
 func TestShutdownForceClose(t *testing.T) {
 	t.Parallel()
 
-	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+	proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	go func() { _ = proxy.Serve() }()
@@ -585,7 +609,7 @@ func TestHTTP11KeepAlive(t *testing.T) {
 		}))
 		t.Cleanup(testServer.Close)
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		go func() { _ = proxy.Serve() }()
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -612,14 +636,9 @@ func TestHTTP11KeepAlive(t *testing.T) {
 			_, err = conn.Write([]byte(request))
 			require.NoError(t, err, "request %d write failed", i)
 
-			// Read response
-			_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-			buf := make([]byte, 4096)
-			n, err := conn.Read(buf)
-			require.NoError(t, err, "request %d read failed", i)
-
-			response := string(buf[:n])
-			assert.Contains(t, response, "HTTP/1.1 200", "request %d should succeed", i)
+			// Read response (streaming may split head and body across reads)
+			response := readResponse(t, conn)
+			assert.Contains(t, response, "200 OK", "request %d should succeed", i)
 			assert.Contains(t, response, "response "+path, "request %d body", i)
 		}
 
@@ -645,7 +664,7 @@ func TestHTTP11KeepAlive(t *testing.T) {
 		}))
 		t.Cleanup(testServer.Close)
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		go func() { _ = proxy.Serve() }()
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -714,7 +733,7 @@ func TestHTTP11KeepAlive(t *testing.T) {
 		}))
 		t.Cleanup(server2.Close)
 
-		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{})
+		proxy, err := NewProxyServer(0, t.TempDir(), 10*1024*1024, store.NewMemStorage(), TimeoutConfig{}, false)
 		require.NoError(t, err)
 		go func() { _ = proxy.Serve() }()
 		t.Cleanup(func() { _ = proxy.Shutdown(context.Background()) })
@@ -738,11 +757,9 @@ func TestHTTP11KeepAlive(t *testing.T) {
 		_, err = conn.Write([]byte(request1))
 		require.NoError(t, err)
 
-		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-		buf := make([]byte, 4096)
-		n, err := conn.Read(buf)
-		require.NoError(t, err)
-		assert.Contains(t, string(buf[:n]), "server1")
+		// Streaming forwards the head and body as separate writes, so drain until
+		// the full response body arrives rather than assuming a single Read.
+		assert.Contains(t, readResponse(t, conn), "server1")
 
 		// Request to server2 on same proxy connection
 		request2 := "GET " + server2.URL + "/path2 HTTP/1.1\r\n" +
@@ -754,10 +771,7 @@ func TestHTTP11KeepAlive(t *testing.T) {
 		_, err = conn.Write([]byte(request2))
 		require.NoError(t, err)
 
-		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-		n, err = conn.Read(buf)
-		require.NoError(t, err)
-		assert.Contains(t, string(buf[:n]), "server2")
+		assert.Contains(t, readResponse(t, conn), "server2")
 
 		// Both requests should be in history
 		testutil.WaitForCount(t, func() int { return proxy.History().Count() }, 2)

--- a/sectool/service/proxy/types/flow.go
+++ b/sectool/service/proxy/types/flow.go
@@ -56,6 +56,11 @@ type Flow struct {
 
 // ExtractMeta builds HistoryMeta from a Flow using its accessor methods.
 func (f *Flow) ExtractMeta() HistoryMeta {
+	// zero CompletedAt marks an in-progress stream; report zero duration
+	var duration time.Duration
+	if !f.CompletedAt.IsZero() {
+		duration = f.CompletedAt.Sub(f.StartedAt)
+	}
 	return HistoryMeta{
 		FlowID:       f.FlowID,
 		Protocol:     f.ProtocolTag,
@@ -70,7 +75,7 @@ func (f *Flow) ExtractMeta() HistoryMeta {
 		ContentType:  f.GetResponseHeader("content-type"),
 		RespLen:      f.responseBodyLen(),
 		Timestamp:    f.StartedAt,
-		Duration:     f.CompletedAt.Sub(f.StartedAt),
+		Duration:     duration,
 		Annotations:  f.Annotations,
 
 		InvokedBy:         f.InvokedBy,

--- a/sectool/service/proxy/types/serialize.go
+++ b/sectool/service/proxy/types/serialize.go
@@ -82,8 +82,24 @@ func (r *RawHTTP1Request) SerializeRaw(buf *bytes.Buffer) []byte {
 // Emits headers and body exactly as parsed; no auto-cleanup.
 func (r *RawHTTP1Response) SerializeRaw(buf *bytes.Buffer) []byte {
 	buf.Reset()
+	r.writeStatusLine(buf)
+	writeRawHTTP1Body(buf, r.Headers, r.Body, r.Trailers, r.Chunks, r.Wire, r.HeaderBlockEnding)
+	return buf.Bytes()
+}
 
-	// Status line
+// SerializeHead returns the status line, headers, and header-block terminator in
+// wire form, without the body. Used to forward a streaming response's head
+// before its body units arrive; preserves original endings and headers verbatim
+// (unlike the lossy SerializeHeaders).
+func (r *RawHTTP1Response) SerializeHead(buf *bytes.Buffer) []byte {
+	buf.Reset()
+	r.writeStatusLine(buf)
+	writeRawHTTP1HeaderBlock(buf, r.Headers, r.HeaderBlockEnding)
+	return buf.Bytes()
+}
+
+// writeStatusLine writes the response status line and its terminator.
+func (r *RawHTTP1Response) writeStatusLine(buf *bytes.Buffer) {
 	buf.WriteString(r.Version)
 	buf.WriteByte(' ')
 	buf.WriteString(strconv.Itoa(r.StatusCode))
@@ -92,9 +108,6 @@ func (r *RawHTTP1Response) SerializeRaw(buf *bytes.Buffer) []byte {
 		buf.WriteString(r.StatusText)
 	}
 	buf.WriteString(r.StatusLineEnding.Bytes())
-
-	writeRawHTTP1Body(buf, r.Headers, r.Body, r.Trailers, r.Chunks, r.Wire, r.HeaderBlockEnding)
-	return buf.Bytes()
 }
 
 // writeRawHTTP1Body writes headers, header-block terminator, and body for an
@@ -102,17 +115,21 @@ func (r *RawHTTP1Response) SerializeRaw(buf *bytes.Buffer) []byte {
 // are emitted verbatim; chunked re-framing fires only when Wire.WasChunked
 // is set. Callers are responsible for setting Content-Length when appropriate.
 func writeRawHTTP1Body(buf *bytes.Buffer, headers Headers, body, trailers []byte, chunks []ChunkFrame, wire *WireFormat, blockEnding LineEnding) {
-	for _, h := range headers {
-		writeHeaderRaw(buf, h)
-	}
-
-	buf.WriteString(blockEnding.Bytes()) // Header terminator
+	writeRawHTTP1HeaderBlock(buf, headers, blockEnding)
 
 	if wire != nil && wire.WasChunked {
 		writeChunkedBody(buf, body, trailers, chunks, summaryLineEnd(wire))
 	} else {
 		buf.Write(body)
 	}
+}
+
+// writeRawHTTP1HeaderBlock writes headers verbatim followed by the header-block terminator.
+func writeRawHTTP1HeaderBlock(buf *bytes.Buffer, headers Headers, blockEnding LineEnding) {
+	for _, h := range headers {
+		writeHeaderRaw(buf, h)
+	}
+	buf.WriteString(blockEnding.Bytes())
 }
 
 // writeHeaderRaw writes a header preserving wire fidelity.
@@ -161,16 +178,27 @@ func writeChunkedBody(buf *bytes.Buffer, body, trailers []byte, chunks []ChunkFr
 		return
 	}
 
-	if len(body) > 0 {
-		buf.WriteString(strconv.FormatInt(int64(len(body)), 16))
-		buf.WriteString(lineEnd)
-		buf.Write(body)
-		buf.WriteString(lineEnd)
+	WriteChunk(buf, body, lineEnd)
+	WriteLastChunk(buf, trailers, lineEnd)
+}
+
+// WriteChunk writes one chunked-encoding frame: hex size, data, and terminators.
+// Empty data writes nothing, since a zero-length frame would end the body early.
+// Used to forward one streaming body unit whose length may differ from the origin.
+func WriteChunk(buf *bytes.Buffer, data []byte, lineEnd string) {
+	if len(data) == 0 {
+		return
 	}
-	// Final chunk
+	buf.WriteString(strconv.FormatInt(int64(len(data)), 16))
+	buf.WriteString(lineEnd)
+	buf.Write(data)
+	buf.WriteString(lineEnd)
+}
+
+// WriteLastChunk writes the terminal 0-size frame and any trailer bytes.
+func WriteLastChunk(buf *bytes.Buffer, trailers []byte, lineEnd string) {
 	buf.WriteByte('0')
 	buf.WriteString(lineEnd)
-	// Trailers if present
 	if len(trailers) > 0 {
 		buf.Write(trailers)
 	}

--- a/sectool/service/proxy/types/serialize_test.go
+++ b/sectool/service/proxy/types/serialize_test.go
@@ -110,6 +110,90 @@ func TestRawHTTP1Response_SerializeRaw(t *testing.T) {
 	})
 }
 
+func TestRawHTTP1Response_SerializeHead(t *testing.T) {
+	t.Parallel()
+
+	t.Run("preserves_headers_verbatim", func(t *testing.T) {
+		// unlike SerializeHeaders, TE:chunked and the original Content-Length are kept, no body
+		r := &RawHTTP1Response{
+			Version:    "HTTP/1.1",
+			StatusCode: 200,
+			StatusText: "OK",
+			Headers: Headers{
+				{Name: "Transfer-Encoding", Value: "chunked"},
+				{Name: "Content-Type", Value: "text/event-stream"},
+			},
+			StatusLineEnding:  EndingCRLF,
+			HeaderBlockEnding: EndingCRLF,
+			Body:              []byte("ignored"),
+		}
+		var buf bytes.Buffer
+		assert.Equal(t, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Type: text/event-stream\r\n\r\n", string(r.SerializeHead(&buf)))
+	})
+
+	t.Run("matches_head_slice_of_serialize_raw", func(t *testing.T) {
+		r := &RawHTTP1Response{
+			Version:           "HTTP/1.1",
+			StatusCode:        200,
+			StatusText:        "OK",
+			Headers:           Headers{{Name: "Content-Length", Value: "3"}},
+			StatusLineEnding:  EndingCRLF,
+			HeaderBlockEnding: EndingCRLF,
+			Body:              []byte("abc"),
+		}
+		var headBuf, rawBuf bytes.Buffer
+		head := string(r.SerializeHead(&headBuf))
+		raw := string(r.SerializeRaw(&rawBuf))
+		assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\n", head)
+		assert.Equal(t, head+"abc", raw)
+	})
+
+	t.Run("preserves_bare_lf", func(t *testing.T) {
+		r := &RawHTTP1Response{
+			Version:           "HTTP/1.1",
+			StatusCode:        200,
+			StatusText:        "OK",
+			Headers:           Headers{{Name: "X-Test", Value: "1", LineEnding: EndingBareLF}},
+			StatusLineEnding:  EndingBareLF,
+			HeaderBlockEnding: EndingBareLF,
+		}
+		var buf bytes.Buffer
+		assert.Equal(t, "HTTP/1.1 200 OK\nX-Test: 1\n\n", string(r.SerializeHead(&buf)))
+	})
+}
+
+func TestWriteChunk(t *testing.T) {
+	t.Parallel()
+
+	t.Run("hex_size_and_terminators", func(t *testing.T) {
+		var buf bytes.Buffer
+		WriteChunk(&buf, []byte("0123456789ABCDEF"), "\r\n") // 16 bytes -> "10"
+		assert.Equal(t, "10\r\n0123456789ABCDEF\r\n", buf.String())
+	})
+
+	t.Run("empty_writes_nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		WriteChunk(&buf, nil, "\r\n")
+		assert.Empty(t, buf.String())
+	})
+}
+
+func TestWriteLastChunk(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no_trailers", func(t *testing.T) {
+		var buf bytes.Buffer
+		WriteLastChunk(&buf, nil, "\r\n")
+		assert.Equal(t, "0\r\n\r\n", buf.String())
+	})
+
+	t.Run("with_trailers", func(t *testing.T) {
+		var buf bytes.Buffer
+		WriteLastChunk(&buf, []byte("X-Trailer: v\r\n"), "\r\n")
+		assert.Equal(t, "0\r\nX-Trailer: v\r\n\r\n", buf.String())
+	})
+}
+
 func TestRawHTTP1Response_SerializeHeaders(t *testing.T) {
 	t.Parallel()
 

--- a/sectool/service/proxy/types/types.go
+++ b/sectool/service/proxy/types/types.go
@@ -497,6 +497,16 @@ type RuleApplier interface {
 	// Does not apply header rules.
 	ApplyResponseBodyOnlyRules(body []byte, headers Headers) []byte
 
+	// ApplyRequestHeaderOnlyRules applies only request header rules to headers.
+	// Used when a request head is processed before its body (H2, streaming).
+	// Returns the possibly-modified headers; does not apply body rules.
+	ApplyRequestHeaderOnlyRules(headers Headers) Headers
+
+	// ApplyResponseHeaderOnlyRules applies only response header rules to headers.
+	// Used when a response head is forwarded before its body (H2, streaming).
+	// Returns the possibly-modified headers; does not apply body rules.
+	ApplyResponseHeaderOnlyRules(headers Headers) Headers
+
 	// ApplyWSRules applies WebSocket rules to frame payload.
 	// direction is "ws:to-server" or "ws:to-client".
 	ApplyWSRules(payload []byte, direction string) []byte

--- a/sectool/service/server.go
+++ b/sectool/service/server.go
@@ -434,7 +434,7 @@ func (s *Server) startBuiltinProxy() error {
 		WriteTimeout: time.Duration(s.cfg.Proxy.WriteTimeoutSecs) * time.Second,
 	}
 
-	backend, err := NewNativeProxyBackend(s.proxyPort, configDir, s.cfg.MaxBodyBytes, s.storageProvider, timeouts)
+	backend, err := NewNativeProxyBackend(s.proxyPort, configDir, s.cfg.MaxBodyBytes, s.storageProvider, timeouts, s.cfg.Proxy.FullBuffer)
 	if err != nil {
 		return fmt.Errorf("start built-in proxy: %w", err)
 	}

--- a/sectool/service/sidecar_dial_e2e_test.go
+++ b/sectool/service/sidecar_dial_e2e_test.go
@@ -102,7 +102,7 @@ func startForward(t *testing.T, name string, caps wire.Capabilities, scope func(
 	dialFn func(*forwardHandler, wire.StreamOpenParams) (wire.DialUpstreamParams, error)) *forwardHarness {
 	t.Helper()
 	socket := filepath.Join(t.TempDir(), "sidecar.sock")
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	srv, err := NewServer(MCPServerFlags{

--- a/sectool/service/sidecar_flow_e2e_test.go
+++ b/sectool/service/sidecar_flow_e2e_test.go
@@ -37,7 +37,7 @@ func TestSidecarFlowEmissionE2E(t *testing.T) {
 	instanceID := uuid.NewString()
 
 	socket := filepath.Join(t.TempDir(), "sidecar.sock")
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	srv, err := NewServer(MCPServerFlags{

--- a/sectool/service/sidecar_intercept_e2e_test.go
+++ b/sectool/service/sidecar_intercept_e2e_test.go
@@ -74,7 +74,7 @@ type interceptHarness struct {
 func startIntercept(t *testing.T, name string, caps wire.Capabilities, probeMarker []byte) *interceptHarness {
 	t.Helper()
 	socket := filepath.Join(t.TempDir(), "sidecar.sock")
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	srv, err := NewServer(MCPServerFlags{

--- a/sectool/service/sidecar_originate_e2e_test.go
+++ b/sectool/service/sidecar_originate_e2e_test.go
@@ -38,7 +38,7 @@ func startOriginateHarness(t *testing.T, allowedDomains []string) *originateHarn
 	const adapter = "origin-sidecar"
 
 	socket := filepath.Join(t.TempDir(), "sidecar.sock")
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	configPath := filepath.Join(t.TempDir(), "config.json")

--- a/sectool/service/sidecar_replay_e2e_test.go
+++ b/sectool/service/sidecar_replay_e2e_test.go
@@ -40,7 +40,7 @@ func TestSidecarReplaySendE2E(t *testing.T) {
 	const adapterName = "mqtt"
 
 	socket := filepath.Join(t.TempDir(), "sidecar.sock")
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	srv, err := NewServer(MCPServerFlags{

--- a/sectool/service/sidecar_replay_sink.go
+++ b/sectool/service/sidecar_replay_sink.go
@@ -33,8 +33,22 @@ func (s *replayRoutingSink) Store(flow *types.Flow) string {
 	return s.history.Store(flow)
 }
 
+// Complete attaches a response to an already-stored flow, routing replay-owned
+// flow ids (unknown to proxy history) to the replay store.
 func (s *replayRoutingSink) Complete(flowID string, resp *types.Message, completedAt time.Time, annotations map[string]any) bool {
-	return s.history.Complete(flowID, resp, completedAt, annotations)
+	if s.history.Complete(flowID, resp, completedAt, annotations) {
+		return true
+	}
+	var status int
+	var respHeaders, respBody []byte
+	if resp != nil {
+		status = resp.StatusCode
+		var buf bytes.Buffer
+		respHeaders, respBody = splitHeadersBody((&types.Flow{Response: resp}).FormatResponse(&buf))
+		respHeaders = slices.Clone(respHeaders)
+		respBody = slices.Clone(respBody)
+	}
+	return s.replay.Complete(flowID, respHeaders, respBody, status, completedAt)
 }
 
 func (s *replayRoutingSink) SetInvokedBy(flowID, invokedBy string) bool {

--- a/sectool/service/sidecar_tools_e2e_test.go
+++ b/sectool/service/sidecar_tools_e2e_test.go
@@ -58,7 +58,7 @@ func TestSidecarToolsE2E(t *testing.T) {
 	const toolName = "custom_echo"
 
 	socket := filepath.Join(t.TempDir(), "sidecar.sock")
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	srv, err := NewServer(MCPServerFlags{
@@ -153,7 +153,7 @@ func TestSidecarToolsE2E(t *testing.T) {
 }
 
 func TestSidecarToolsAbsentWithoutSidecar(t *testing.T) {
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	srv, err := NewServer(MCPServerFlags{

--- a/sectool/service/sidecar_upgrade_e2e_test.go
+++ b/sectool/service/sidecar_upgrade_e2e_test.go
@@ -57,7 +57,7 @@ type upgradeHarness struct {
 func startUpgrade(t *testing.T, name string, caps wire.Capabilities) *upgradeHarness {
 	t.Helper()
 	socket := filepath.Join(t.TempDir(), "sidecar.sock")
-	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{})
+	backend, err := NewNativeProxyBackend(0, t.TempDir(), 10*1024*1024, store.MemProvider, proxy.TimeoutConfig{}, false)
 	require.NoError(t, err)
 
 	srv, err := NewServer(MCPServerFlags{

--- a/sectool/service/store/replay_history.go
+++ b/sectool/service/store/replay_history.go
@@ -101,7 +101,34 @@ func (s *ReplayHistoryStore) Store(entry *ReplayHistoryEntry) {
 	if entry.CreatedAt.IsZero() {
 		entry.CreatedAt = time.Now()
 	}
+	if s.persistLocked(entry) {
+		s.count++
+	}
+}
 
+// Complete attaches a response to an already-stored replay entry: the two-phase
+// form used for deferred and streaming replays. A non-zero completedAt records the
+// elapsed duration. Returns false when flowID is unknown.
+func (s *ReplayHistoryStore) Complete(flowID string, respHeaders, respBody []byte, status int, completedAt time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.getLocked(flowID)
+	if !ok {
+		return false
+	}
+	entry.RespHeaders = respHeaders
+	entry.RespBody = respBody
+	entry.RespStatus = status
+	if !completedAt.IsZero() {
+		entry.Duration = completedAt.Sub(entry.CreatedAt)
+	}
+	return s.persistLocked(entry)
+}
+
+// persistLocked writes an entry to storage, returning false on failure.
+// Caller must hold mu.
+func (s *ReplayHistoryStore) persistLocked(entry *ReplayHistoryEntry) bool {
 	meta := ReplayHistoryMeta{
 		FlowID:       entry.FlowID,
 		Method:       entry.Method,
@@ -128,19 +155,19 @@ func (s *ReplayHistoryStore) Store(entry *ReplayHistoryEntry) {
 
 	if metaData, err := Serialize(&meta); err != nil {
 		log.Printf("replay history store serialize meta error: %v", err)
-		return
+		return false
 	} else if payloadData, err := Serialize(&payload); err != nil {
 		log.Printf("replay history store serialize payload error: %v", err)
-		return
+		return false
 	} else if err := s.storage.Set(entry.FlowID, metaData); err != nil {
 		log.Printf("replay history store save meta error: %v", err)
-		return
+		return false
 	} else if err := s.storage.Set(entry.FlowID+replayPayloadSuffix, payloadData); err != nil {
 		log.Printf("replay history store save payload error: %v", err)
 		_ = s.storage.Delete(entry.FlowID) // rollback meta key
-		return
+		return false
 	}
-	s.count++
+	return true
 }
 
 // Get retrieves a replay entry by flow_id.

--- a/sectool/service/store/replay_history_test.go
+++ b/sectool/service/store/replay_history_test.go
@@ -137,6 +137,58 @@ func TestReplayHistoryStore(t *testing.T) {
 	})
 }
 
+func TestReplayHistoryComplete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("updates_response_and_meta", func(t *testing.T) {
+		storage := NewMemStorage()
+		t.Cleanup(func() { _ = storage.Close() })
+		store := NewReplayHistoryStore(storage)
+
+		created := time.Now().Add(-time.Second)
+		store.Store(&ReplayHistoryEntry{FlowID: "f1", Method: "GET", CreatedAt: created})
+		require.Equal(t, 1, store.Count())
+
+		completedAt := created.Add(250 * time.Millisecond)
+		require.True(t, store.Complete("f1", []byte("HTTP/1.1 200 OK\r\n\r\n"), []byte("data: one\n\n"), 200, completedAt))
+
+		got, ok := store.Get("f1")
+		require.True(t, ok)
+		assert.Equal(t, 200, got.RespStatus)
+		assert.Equal(t, "data: one\n\n", string(got.RespBody))
+		assert.Equal(t, 250*time.Millisecond, got.Duration)
+
+		// Cached meta stays in sync; Complete does not change count
+		assert.Equal(t, 1, store.Count())
+		metas := store.ListMeta()
+		require.Len(t, metas, 1)
+		assert.Equal(t, 200, metas[0].RespStatus)
+		assert.Equal(t, len("data: one\n\n"), metas[0].RespLen)
+		assert.Equal(t, 250*time.Millisecond, metas[0].Duration)
+	})
+
+	t.Run("unknown_flow", func(t *testing.T) {
+		storage := NewMemStorage()
+		t.Cleanup(func() { _ = storage.Close() })
+		store := NewReplayHistoryStore(storage)
+		assert.False(t, store.Complete("missing", nil, nil, 200, time.Now()))
+	})
+
+	t.Run("in_progress_leaves_duration_zero", func(t *testing.T) {
+		storage := NewMemStorage()
+		t.Cleanup(func() { _ = storage.Close() })
+		store := NewReplayHistoryStore(storage)
+
+		store.Store(&ReplayHistoryEntry{FlowID: "f2", Method: "GET"})
+		require.True(t, store.Complete("f2", nil, []byte("partial"), 200, time.Time{}))
+
+		got, ok := store.Get("f2")
+		require.True(t, ok)
+		assert.Equal(t, "partial", string(got.RespBody))
+		assert.Zero(t, got.Duration)
+	})
+}
+
 func TestReplayHistoryListMeta(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
HTTP/2 already was streaming responses (if no rules). Now by default all protocols will stream responses to the client and into the history record.

This means that clients may need to get flows multiple times to get additional data if the response is still active.

This notably improves streaming responses and SSE protocol testing.

The only down side is that rules may not match across chunk boundaries. If this is problematic for you, you can disable this feature to restore the fully buffered response.